### PR TITLE
fix(installer): use cross-platform locking instead of flock

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,13 +150,18 @@ if [ "$FROM_SOURCE" -eq 0 ]; then
   fi
 fi
 
-exec 9>"$LOCK_FILE" || true
+# Cross-platform locking (mkdir is atomic on all Unix systems)
 LOCKED=0
-if flock -n 9; then LOCKED=1; else err "Another installer is running (lock $LOCK_FILE)"; exit 1; fi
+if mkdir "$LOCK_FILE" 2>/dev/null; then
+  LOCKED=1
+else
+  err "Another installer is running (lock $LOCK_FILE)"
+  exit 1
+fi
 
 cleanup() {
   rm -rf "$TMP"
-  if [ "$LOCKED" -eq 1 ]; then rm -f "$LOCK_FILE"; fi
+  if [ "$LOCKED" -eq 1 ]; then rm -rf "$LOCK_FILE"; fi
 }
 
 TMP=$(mktemp -d)


### PR DESCRIPTION
## Summary

- Replace Linux-specific `flock` with `mkdir`-based locking
- Works on all POSIX systems including macOS

Fixes #1

## Test plan

- [ ] Test on macOS: `curl -fsSL ... | bash -s -- --easy-mode --verify`
- [ ] Test on Linux: same command
- [ ] Verify lock prevents concurrent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)