### PR TITLE
Add RepoPrompt connector and wire into indexer, CLI, TUI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
 **Unified, high-performance TUI to index and search your local coding agent history.**
-Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, and Pi-Agent into a single, searchable timeline.
+Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, and RepoPrompt into a single, searchable timeline.
 
 <div align="center">
 
@@ -30,7 +30,7 @@ install.ps1 -EasyMode -Verify
 <div align="center">
 
 ### Search Results Across All Your Agents
-*Three-pane layout: filter bar, results list with color-coded agents (Claude, Codex, Gemini, Pi-Agent, etc.), and syntax-highlighted detail preview*
+*Three-pane layout: filter bar, results list with color-coded agents (Claude, Codex, Gemini, Pi-Agent, RepoPrompt, etc.), and syntax-highlighted detail preview*
 
 <img src="screenshots/screenshot_01.webp" alt="Main TUI showing search results across multiple coding agents" width="800">
 
@@ -56,7 +56,7 @@ install.ps1 -EasyMode -Verify
 
 ### The Problem
 
-AI coding agents are transforming how we write software. Claude Code, Codex, Cursor, Copilot, Aider, Pi-Agent; each creates a trail of conversations, debugging sessions, and problem-solving attempts. But this wealth of knowledge is **scattered and unsearchable**:
+AI coding agents are transforming how we write software. Claude Code, Codex, Cursor, Copilot, Aider, Pi-Agent, RepoPrompt; each creates a trail of conversations, debugging sessions, and problem-solving attempts. But this wealth of knowledge is **scattered and unsearchable**:
 
 - **Fragmented storage**: Each agent stores data differently—JSONL files, SQLite databases, markdown logs, proprietary JSON formats
 - **No cross-agent visibility**: Solutions discovered in Cursor are invisible when you're using Claude Code
@@ -121,6 +121,7 @@ Ingests history from all major local agents, normalizing them into a unified `Co
 - **ChatGPT**: `~/Library/Application Support/com.openai.chat` (v1 unencrypted JSON; v2/v3 encrypted—see Environment)
 - **Aider**: `~/.aider.chat.history.md` and per-project `.aider.chat.history.md` files (Markdown)
 - **Pi-Agent**: `~/.pi/agent/sessions` (Session JSONL with thinking content)
+- **RepoPrompt**: `~/Library/Application Support/RepoPrompt/Workspaces/*/Chats` (Chat JSON)
 
 ## 🤖 AI / Automation Mode
 
@@ -472,7 +473,7 @@ When an exact query returns fewer than 3 results, `cass` automatically retries w
 | `F1` or `?` | Toggle help screen |
 | `F2` | Toggle dark/light theme |
 | `Ctrl+B` | Toggle border style (rounded/plain) |
-| `Ctrl+Shift+R` | Force re-index |
+| `Ctrl+Shift+R` | Reload index/view (refresh search results from the latest on-disk index; use after running `cass index` outside the TUI) |
 | `Ctrl+Shift+Del` | Reset all TUI state |
 
 ### Search Bar (Query Input)
@@ -991,7 +992,7 @@ graph TD
  Input([User Input]) -->|Key/Mouse| EventLoop
  EventLoop -->|Update| State[App State]
  State -->|Render| Terminal
- 
+
  State -->|Query Change| Debounce{Debounce}
  Debounce -->|Fire| SearchTask[Async Search]
  SearchTask -->|Results| Channel

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -13,6 +13,7 @@ pub mod cursor;
 pub mod gemini;
 pub mod opencode;
 pub mod pi_agent;
+pub mod repoprompt;
 
 /// High-level detection status for a connector.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/connectors/repoprompt.rs
+++ b/src/connectors/repoprompt.rs
@@ -1,0 +1,290 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use walkdir::WalkDir;
+
+use crate::connectors::{
+    Connector, DetectionResult, NormalizedConversation, NormalizedMessage, ScanContext,
+};
+
+const APPLE_UNIX_OFFSET_SECS: f64 = 978_307_200.0;
+
+pub struct RepoPromptConnector;
+
+impl Default for RepoPromptConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RepoPromptConnector {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn home() -> PathBuf {
+        std::env::var("REPOPROMPT_HOME").map_or_else(
+            |_| {
+                dirs::data_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("RepoPrompt")
+                    .join("Workspaces")
+            },
+            PathBuf::from,
+        )
+    }
+
+    fn session_files(root: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        for entry in WalkDir::new(root).into_iter().flatten() {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+            if name.starts_with("ChatSession-")
+                && name.ends_with(".json")
+                && path
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    == Some("Chats")
+            {
+                files.push(path.to_path_buf());
+            }
+        }
+        files
+    }
+
+    fn parse_timestamp_apple(val: &Value) -> Option<i64> {
+        if let Some(secs) = val.as_f64() {
+            let unix_secs = secs + APPLE_UNIX_OFFSET_SECS;
+            return Some((unix_secs * 1000.0).round() as i64);
+        }
+
+        if let Some(secs) = val.as_i64() {
+            let unix_secs = secs as f64 + APPLE_UNIX_OFFSET_SECS;
+            return Some((unix_secs * 1000.0).round() as i64);
+        }
+
+        crate::connectors::parse_timestamp(val)
+    }
+
+    fn derive_workspace(paths: &[PathBuf]) -> Option<PathBuf> {
+        if paths.is_empty() {
+            return None;
+        }
+
+        let mut iter = paths.iter().filter_map(|p| p.parent().map(PathBuf::from));
+        let first = iter.next()?;
+        let mut prefix_components: Vec<_> = first.components().collect();
+
+        for path in iter {
+            let comps: Vec<_> = path.components().collect();
+            let mut new_len = 0;
+            for (a, b) in prefix_components.iter().zip(&comps) {
+                if a == b {
+                    new_len += 1;
+                } else {
+                    break;
+                }
+            }
+            prefix_components.truncate(new_len);
+            if prefix_components.is_empty() {
+                break;
+            }
+        }
+
+        if prefix_components.is_empty() {
+            return None;
+        }
+
+        let mut out = PathBuf::new();
+        for c in prefix_components {
+            out.push(c);
+        }
+        Some(out)
+    }
+}
+
+impl Connector for RepoPromptConnector {
+    fn detect(&self) -> DetectionResult {
+        let home = Self::home();
+        if home.exists() {
+            DetectionResult {
+                detected: true,
+                evidence: vec![format!("found {}", home.display())],
+            }
+        } else {
+            DetectionResult::not_found()
+        }
+    }
+
+    fn scan(&self, ctx: &ScanContext) -> Result<Vec<NormalizedConversation>> {
+        let root = {
+            let looks_like_repoprompt = ctx
+                .data_root
+                .to_string_lossy()
+                .to_lowercase()
+                .contains("repoprompt");
+
+            if looks_like_repoprompt || ctx.data_root.join("Chats").exists() {
+                ctx.data_root.clone()
+            } else {
+                Self::home()
+            }
+        };
+
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let files = Self::session_files(&root);
+        let mut convs = Vec::new();
+
+        for file in files {
+            if !crate::connectors::file_modified_since(&file, ctx.since_ts) {
+                continue;
+            }
+
+            let content = fs::read_to_string(&file)
+                .with_context(|| format!("read repoprompt chat {}", file.display()))?;
+
+            let val: Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let session_id = val.get("id").and_then(|v| v.as_str()).map(String::from);
+            let short_id = val
+                .get("shortID")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let workspace_id = val
+                .get("workspaceID")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let name = val.get("name").and_then(|v| v.as_str()).map(String::from);
+            let preferred_model = val
+                .get("preferredAIModel")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let saved_at = val.get("savedAt").and_then(Self::parse_timestamp_apple);
+
+            let mut workspace_paths: Vec<PathBuf> = Vec::new();
+            if let Some(arr) = val.get("selectedFilePaths").and_then(|v| v.as_array()) {
+                for p in arr.iter().filter_map(|v| v.as_str()) {
+                    workspace_paths.push(PathBuf::from(p));
+                }
+            }
+
+            let Some(messages_arr) = val.get("messages").and_then(|m| m.as_array()) else {
+                continue;
+            };
+
+            let mut messages = Vec::new();
+            let mut started_at = None;
+            let mut ended_at = saved_at;
+
+            for item in messages_arr {
+                let is_user = item.get("isUser").and_then(|v| v.as_bool()).unwrap_or(true);
+                let role = if is_user { "user" } else { "assistant" };
+
+                let created = item.get("timestamp").and_then(Self::parse_timestamp_apple);
+
+                if let Some(ts) = created {
+                    started_at = started_at.or(Some(ts));
+                    ended_at = Some(ended_at.map_or(ts, |prev| prev.max(ts)));
+                }
+
+                let content_str = item
+                    .get("rawText")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                if content_str.trim().is_empty() {
+                    continue;
+                }
+
+                let author = if is_user {
+                    Some("user".to_string())
+                } else {
+                    item.get("modelName")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                };
+
+                if let Some(arr) = item.get("allowedFilePaths").and_then(|v| v.as_array()) {
+                    for p in arr.iter().filter_map(|v| v.as_str()) {
+                        workspace_paths.push(PathBuf::from(p));
+                    }
+                }
+
+                messages.push(NormalizedMessage {
+                    idx: 0,
+                    role: role.to_string(),
+                    author,
+                    created_at: created,
+                    content: content_str,
+                    extra: item.clone(),
+                    snippets: Vec::new(),
+                });
+            }
+
+            if messages.is_empty() {
+                continue;
+            }
+
+            for (i, msg) in messages.iter_mut().enumerate() {
+                msg.idx = i as i64;
+            }
+
+            let title = name.or_else(|| {
+                messages
+                    .iter()
+                    .find(|m| m.role == "user")
+                    .or_else(|| messages.first())
+                    .map(|m| {
+                        m.content
+                            .lines()
+                            .next()
+                            .unwrap_or(&m.content)
+                            .chars()
+                            .take(100)
+                            .collect()
+                    })
+            });
+
+            let workspace = Self::derive_workspace(&workspace_paths)
+                .or_else(|| file.parent().and_then(|p| p.parent()).map(PathBuf::from));
+
+            let metadata = serde_json::json!({
+                "source": "repoprompt",
+                "session_id": session_id,
+                "short_id": short_id,
+                "workspace_id": workspace_id,
+                "preferred_model": preferred_model,
+                "selected_file_count": workspace_paths.len(),
+            });
+
+            convs.push(NormalizedConversation {
+                agent_slug: "repoprompt".to_string(),
+                external_id: session_id,
+                title,
+                workspace,
+                source_path: file.clone(),
+                started_at,
+                ended_at,
+                metadata,
+                messages,
+            });
+        }
+
+        Ok(convs)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3626,6 +3626,7 @@ fn run_diag(
     // Agent search paths - compute path once, then check existence
     let home = dirs::home_dir().unwrap_or_default();
     let config_dir = dirs::config_dir().unwrap_or_default();
+    let data_root = dirs::data_dir().unwrap_or_default();
 
     let codex_path = home.join(".codex/sessions");
     let claude_path = home.join(".claude/projects");
@@ -3637,6 +3638,7 @@ fn run_diag(
         .unwrap_or_else(|| home.join("Library/Application Support/Cursor/User"));
     let chatgpt_path = crate::connectors::chatgpt::ChatGptConnector::app_support_dir()
         .unwrap_or_else(|| home.join("Library/Application Support/com.openai.chat"));
+    let repoprompt_path = data_root.join("RepoPrompt").join("Workspaces");
 
     let agent_paths: Vec<(&str, &std::path::Path, bool)> = vec![
         ("codex", &codex_path, codex_path.exists()),
@@ -3647,6 +3649,7 @@ fn run_diag(
         ("amp", &amp_path, amp_path.exists()),
         ("cursor", &cursor_path, cursor_path.exists()),
         ("chatgpt", &chatgpt_path, chatgpt_path.exists()),
+        ("repoprompt", &repoprompt_path, repoprompt_path.exists()),
     ];
 
     let platform = std::env::consts::OS;
@@ -4609,6 +4612,7 @@ fn run_capabilities(json: bool) -> CliResult<()> {
             "cursor".to_string(),
             "chatgpt".to_string(),
             "pi_agent".to_string(),
+            "repoprompt".to_string(),
         ],
         limits: CapabilitiesLimits {
             max_limit: 10000,

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -864,7 +864,7 @@ pub fn help_lines(palette: ThemePalette) -> Vec<Line<'static>> {
             "  agent_search.db - Full-text search index".to_string(),
             "  tui_state.json - Persisted UI preferences".to_string(),
             "  update_state.json - Update check state".to_string(),
-            "Agent histories auto-detected from: Claude, Codex, Gemini, Copilot, Cursor"
+            "Agent histories auto-detected from: Claude, Codex, Gemini, Copilot, Cursor, Pi-Agent, RepoPrompt"
                 .to_string(),
         ],
     ));
@@ -898,7 +898,7 @@ pub fn help_lines(palette: ThemePalette) -> Vec<Line<'static>> {
     lines.extend(add_section(
         "Filters",
         &[
-            format!("{} agent | {} workspace | {} from | {} to | {} clear all", 
+            format!("{} agent | {} workspace | {} from | {} to | {} clear all",
                 shortcuts::FILTER_AGENT, shortcuts::FILTER_WORKSPACE, shortcuts::FILTER_DATE_FROM, shortcuts::FILTER_DATE_TO, shortcuts::CLEAR_FILTERS),
             format!("{} scope to active agent | {} clear scope | {} cycle time presets (24h/7d/30d/all)",
                 shortcuts::SCOPE_AGENT, shortcuts::SCOPE_WORKSPACE, shortcuts::CYCLE_TIME_PRESETS),
@@ -1490,6 +1490,11 @@ const KNOWN_AGENTS: &[&str] = &[
     "gemini_cli",
     "amp",
     "opencode",
+    "aider",
+    "cursor",
+    "chatgpt",
+    "pi_agent",
+    "repoprompt",
 ];
 
 /// Returns agent suggestions matching the given prefix (case-insensitive)

--- a/tests/connector_repoprompt.rs
+++ b/tests/connector_repoprompt.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::PathBuf;
+
+use coding_agent_search::connectors::{Connector, ScanContext, repoprompt::RepoPromptConnector};
+use serial_test::serial;
+use tempfile::TempDir;
+
+#[test]
+#[serial]
+fn repoprompt_connector_reads_session_json() {
+    let dir = TempDir::new().unwrap();
+    let workspaces_root = dir.path().join("RepoPrompt").join("Workspaces");
+    let workspace_dir = workspaces_root.join("Workspace-test");
+    let chats_dir = workspace_dir.join("Chats");
+    fs::create_dir_all(&chats_dir).unwrap();
+    let file = chats_dir.join("ChatSession-abc.json");
+
+    let session = serde_json::json!({
+        "id": "chat-1",
+        "shortID": "short-1",
+        "name": "Test Chat",
+        "workspaceID": "WS-123",
+        "preferredAIModel": "repoprompt-model",
+        "selectedFilePaths": [
+            "/tmp/project/README.md",
+            "/tmp/project/src/main.rs",
+        ],
+        "messages": [
+            {
+                "sequenceIndex": 0,
+                "rawText": "user question",
+                "isUser": true,
+                "timestamp": 784523530.0,
+                "allowedFilePaths": serde_json::Value::Null,
+                "modelName": serde_json::Value::Null,
+                "delegateResults": [],
+                "id": "msg-1",
+            },
+            {
+                "sequenceIndex": 1,
+                "rawText": "assistant answer",
+                "isUser": false,
+                "timestamp": 784523531.0,
+                "allowedFilePaths": [
+                    "/tmp/project/README.md",
+                    "/tmp/project/src/main.rs",
+                ],
+                "modelName": "GPT-X",
+                "delegateResults": [],
+                "id": "msg-2",
+            },
+        ],
+        "savedAt": 784523532.0,
+    });
+    fs::write(&file, serde_json::to_string(&session).unwrap()).unwrap();
+
+    unsafe {
+        std::env::set_var("REPOPROMPT_HOME", &workspaces_root);
+    }
+
+    let connector = RepoPromptConnector::new();
+    let ctx = ScanContext {
+        data_root: workspaces_root.clone(),
+        since_ts: None,
+    };
+
+    let convs = connector.scan(&ctx).unwrap();
+    assert_eq!(convs.len(), 1);
+    let c = &convs[0];
+
+    assert_eq!(c.agent_slug, "repoprompt");
+    assert_eq!(c.external_id, Some("chat-1".to_string()));
+    assert_eq!(c.title, Some("Test Chat".to_string()));
+    assert_eq!(c.workspace, Some(PathBuf::from("/tmp/project")));
+    assert_eq!(c.source_path, file);
+    assert_eq!(
+        c.metadata.get("source").and_then(|v| v.as_str()),
+        Some("repoprompt")
+    );
+
+    assert_eq!(c.messages.len(), 2);
+    assert_eq!(c.messages[0].role, "user");
+    assert_eq!(c.messages[0].author, Some("user".to_string()));
+    assert_eq!(c.messages[0].content, "user question".to_string());
+
+    assert_eq!(c.messages[1].role, "assistant");
+    assert_eq!(c.messages[1].author, Some("GPT-X".to_string()));
+    assert_eq!(c.messages[1].content, "assistant answer".to_string());
+
+    assert!(c.started_at.is_some());
+    assert!(c.ended_at.is_some());
+    assert!(c.started_at.unwrap() <= c.ended_at.unwrap());
+
+    assert_eq!(c.messages[0].idx, 0);
+    assert_eq!(c.messages[1].idx, 1);
+}
+
+#[test]
+#[serial]
+fn repoprompt_detect_with_workspaces_dir() {
+    let dir = TempDir::new().unwrap();
+    let workspaces_root = dir.path().join("RepoPrompt").join("Workspaces");
+    fs::create_dir_all(&workspaces_root).unwrap();
+
+    unsafe {
+        std::env::set_var("REPOPROMPT_HOME", &workspaces_root);
+    }
+
+    let connector = RepoPromptConnector::new();
+    let result = connector.detect();
+    assert!(result.detected);
+    assert!(!result.evidence.is_empty());
+}
+
+#[test]
+#[serial]
+fn repoprompt_connector_respects_since_ts_at_file_level() {
+    let dir = TempDir::new().unwrap();
+    let workspaces_root = dir.path().join("RepoPrompt").join("Workspaces");
+    let workspace_dir = workspaces_root.join("Workspace-since");
+    let chats_dir = workspace_dir.join("Chats");
+    fs::create_dir_all(&chats_dir).unwrap();
+    let file = chats_dir.join("ChatSession-since.json");
+
+    let session = serde_json::json!({
+        "id": "chat-since",
+        "selectedFilePaths": ["/tmp/project/file.txt"],
+        "messages": [
+            {
+                "sequenceIndex": 0,
+                "rawText": "old msg",
+                "isUser": true,
+                "timestamp": 784523520.0,
+                "allowedFilePaths": serde_json::Value::Null,
+                "modelName": serde_json::Value::Null,
+                "delegateResults": [],
+                "id": "old",
+            },
+            {
+                "sequenceIndex": 1,
+                "rawText": "new msg",
+                "isUser": false,
+                "timestamp": 784523540.0,
+                "allowedFilePaths": serde_json::Value::Null,
+                "modelName": "GPT-X",
+                "delegateResults": [],
+                "id": "new",
+            },
+        ],
+        "savedAt": 784523545.0,
+    });
+    fs::write(&file, serde_json::to_string(&session).unwrap()).unwrap();
+
+    unsafe {
+        std::env::set_var("REPOPROMPT_HOME", &workspaces_root);
+    }
+
+    let connector = RepoPromptConnector::new();
+    let ctx = ScanContext {
+        data_root: workspaces_root.clone(),
+        since_ts: Some(1_700_000_000_000),
+    };
+
+    let convs = connector.scan(&ctx).unwrap();
+    assert_eq!(convs.len(), 1);
+    let c = &convs[0];
+
+    assert_eq!(c.messages.len(), 2);
+    assert_eq!(c.messages[0].content, "old msg".to_string());
+    assert_eq!(c.messages[1].content, "new msg".to_string());
+}

--- a/tests/fixtures/cli_contract/capabilities.json
+++ b/tests/fixtures/cli_contract/capabilities.json
@@ -36,7 +36,8 @@
     "aider",
     "cursor",
     "chatgpt",
-    "pi_agent"
+    "pi_agent",
+    "repoprompt"
   ],
   "limits": {
     "max_limit": 10000,


### PR DESCRIPTION
# Add RepoPrompt connector to cass

## Summary

This PR adds first-class support for indexing and searching RepoPrompt chat sessions in `cass`, wiring the new connector through the indexing pipeline, CLI capabilities/diagnostics, TUI agent filtering, and test suite.

## Rationale

- RepoPrompt Chat Mode often acts as an orchestration layer that drives Codex CLI, Claude Code, Gemini CLI, etc. via CLI Providers and MCP. The detailed low‑level traces of those runs live in the other agents’ logs, while the workspace‑tied planning, context building, and coordination live in the RepoPrompt chats. Indexing RepoPrompt alongside those agent sessions lets `cass` surface both the orchestration and the underlying execution when you search past work.
- The connector follows existing Codex/Gemini/Pi-Agent patterns and plugs into the same indexer, capabilities, and TUI agent filter surfaces, so downstream consumers and the robot interface see `repoprompt` as just another agent_slug without special‑case handling.

## Changes

- **New RepoPrompt connector** (`src/connectors/repoprompt.rs`)
  - Discovers sessions under `~/Library/Application Support/RepoPrompt/Workspaces/*/Chats/ChatSession-*.json` (with `REPOPROMPT_HOME` override for tests).
  - Parses RepoPrompt chat JSON into `NormalizedConversation` / `NormalizedMessage` records using `rawText` and `isUser` for role mapping.
  - Converts Apple reference timestamps (seconds since 2001-01-01) into Unix milliseconds.
  - Derives `workspace` from `selectedFilePaths` / `allowedFilePaths` by computing their common directory prefix, with a fallback to the RepoPrompt workspace directory.
  - Tags conversations with `agent_slug = "repoprompt"` and stores connector-specific details in `metadata`.

- **Indexer wiring** (`src/indexer/mod.rs`)
  - Adds `RepoPromptConnector` to the `connector_factories` list used by `run_index` for parallel scanning.
  - Extends `watch_roots()` to monitor `data_dir/RepoPrompt/Workspaces`.
  - Adds `ConnectorKind::RepoPrompt` and routes file-system events whose paths include `RepoPrompt/Workspaces` and `/Chats/` to the new connector.
  - Updates `classify_paths_uses_latest_mtime_per_connector` test to include a RepoPrompt example.

- **CLI capabilities & diagnostics** (`src/lib.rs`)
  - Extends `run_diag` to report a `repoprompt` connector entry with its search path under `dirs::data_dir()/RepoPrompt/Workspaces`.
  - Adds `"repoprompt"` to the `connectors` list in `CapabilitiesResponse`.
  - Updates the golden `tests/fixtures/cli_contract/capabilities.json` fixture to keep the robot contract in sync.

- **TUI agent filter suggestions** (`src/ui/tui.rs`)
  - Extends `KNOWN_AGENTS` used by `agent_suggestions()` to include newer connectors, including `repoprompt` (and other missing slugs like `pi_agent`).
  - This ensures `repoprompt` shows up in the Agent filter picker and command palette suggestions.

- **RepoPrompt tests**
  - New connector tests (`tests/connector_repoprompt.rs`):
    - Verify that a synthetic RepoPrompt session JSON is ingested into a `NormalizedConversation` with the correct `agent_slug`, `external_id`, `title`, `workspace`, `source_path`, metadata, timestamps, and messages.
    - Check `detect()` when a Workspaces directory exists.
    - Confirm that `since_ts` is respected only at the file level (both old and new messages remain visible once a file is processed).
  - Parse-error tests (`tests/parse_errors.rs`):
    - Add RepoPrompt cases for invalid JSON and missing `messages`, mirroring the expectations used for Gemini and other connectors.
    - Avoid mutating `REPOPROMPT_HOME` in these tests to keep them safe under parallel test execution.

- **Docs & UX** (`README.md`)
  - Clarify the TUI keyboard reference for `Ctrl+Shift+R` as "Reload index/view (refresh search results from the latest on-disk index; use after running `cass index` outside the TUI)" so users understand why a manual refresh is needed after reindexing.

## Testing Steps Taken

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- Built release: `cargo build --release`.
- Verified diagnostics: `target/release/cass diag --json` shows a `repoprompt` connector with `found: true` and the expected RepoPrompt Workspaces path.
- Ran `target/release/cass index --full` with `RUST_LOG=info` and confirmed `connector="repoprompt"` logs with non-zero conversation counts when RepoPrompt chats exist.
- Verified JSON search: `target/release/cass search "SOMESTRING" --agent repoprompt --limit 5 --json` returns expected local RepoPrompt chats containing SOMESTRING; matching workspace and source path are set as expected.
- In TUI: confirmed that `Ctrl+Shift+R` reloads the index/view so new RepoPrompt results appear, and that `repoprompt` is now available via the Agent filter picker.

🤖 Co-Authored-By: Codex