### PR TITLE
Fix timeline SQL query to use proper JOIN with agents table (Issue #7)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6468,9 +6468,10 @@ fn run_timeline(
     };
 
     let mut sql = String::from(
-        "SELECT c.id, c.agent, c.title, c.started_at, c.ended_at, c.source_path,
+        "SELECT c.id, a.slug as agent, c.title, c.started_at, c.ended_at, c.source_path,
                 COUNT(m.id) as message_count
          FROM conversations c
+         JOIN agents a ON c.agent_id = a.id
          LEFT JOIN messages m ON m.conversation_id = c.id
          WHERE c.started_at >= ?1 AND c.started_at <= ?2",
     );
@@ -6478,7 +6479,7 @@ fn run_timeline(
     let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(start_ts), Box::new(end_ts)];
 
     if !agents.is_empty() {
-        sql.push_str(" AND c.agent IN (");
+        sql.push_str(" AND a.slug IN (");
         for (i, agent) in agents.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");


### PR DESCRIPTION
## Summary
Fixes GitHub issue #7 - the timeline query was incorrectly referencing `c.agent` directly from the conversations table, but it should use a proper JOIN with the agents table to get `a.slug` as the agent identifier.

## Problem
The `run_timeline` function in `src/lib.rs` was using a SQL query that directly selected `c.agent` from the conversations table and filtered using `c.agent IN (...)`. However, the conversations table has an `agent_id` foreign key that references the agents table, not a direct `agent` column.

## Solution
- Changed `SELECT c.agent` to `SELECT a.slug as agent` 
- Added `JOIN agents a ON c.agent_id = a.id` to properly join the tables
- Updated WHERE clause from `c.agent IN (...)` to `a.slug IN (...)` for filtering

## Testing
- [x] Code compiles successfully with `cargo build`
- [x] SQL query follows the same pattern as other queries in the codebase

## Test plan
- [x] Build the project to ensure syntax is correct
- [ ] Test timeline functionality with various agent filters to ensure the query works correctly
- [ ] Verify that timeline results include proper agent names

🤖 Generated with [Claude Code](https://claude.com/claude-code)