### PR TITLE
fix: support Cursor v0.40+ data format and fix conversation selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "colored",
- "console 0.15.11",
+ "console 0.16.1",
  "crc32fast",
  "criterion",
  "crossbeam-channel",
@@ -519,7 +519,7 @@ dependencies = [
  "half",
  "indicatif",
  "insta",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lru",
  "memmap2",
  "notify",
@@ -541,13 +541,14 @@ dependencies = [
  "syntect",
  "tantivy",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "unicode-normalization",
+ "urlencoding",
  "vergen",
  "walkdir",
  "which",
@@ -606,7 +607,6 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3914,6 +3914,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ syntect = "*"
 itertools = "*"
 crc32fast = "*"
 unicode-normalization = "*"
+urlencoding = "2.1"
 half = "*"
 memmap2 = "*"
 fastembed = { version = "*", default-features = false, features = ["ort-download-binaries"] }

--- a/todos/001-completed-p2-bubble-data-memory-usage.md
+++ b/todos/001-completed-p2-bubble-data-memory-usage.md
@@ -1,0 +1,99 @@
+---
+status: completed
+priority: p2
+issue_id: "001"
+tags: [code-review, performance, memory]
+dependencies: []
+---
+
+# P2: Pre-fetching All Bubble Data Causes Memory Spike
+
+## Problem Statement
+
+The `fetch_bubble_data()` function loads ALL `bubbleId:*` rows into a HashMap upfront before processing any conversations. For users with 1500+ conversations (~30,000 bubble entries), this creates a ~60MB memory spike during indexing.
+
+**Why it matters:** At scale (100x), this could consume 6GB of memory. Users with large Cursor installations may experience slow indexing or memory pressure.
+
+## Findings
+
+**Source:** Performance Oracle Agent
+
+**Location:** `src/connectors/cursor.rs`, lines 172-208 and 429
+
+```rust
+// Line 429 - loads ALL bubble data before processing
+let bubble_data = Self::fetch_bubble_data(&conn);
+```
+
+**Evidence:**
+- `fetch_bubble_data` queries ALL `bubbleId:*` keys (~30,000 for 1500 conversations)
+- Each bubble contains full JSON with message content (several KB each)
+- Memory estimate: 30,000 bubbles × 2KB avg = ~60MB
+- This happens before any `since_ts` filtering
+
+**Projected Impact:**
+| Conversations | Bubbles | Memory Usage | Parse Time |
+|--------------|---------|--------------|------------|
+| 1,500 | 30,000 | ~60MB | ~2-3s |
+| 15,000 | 300,000 | ~600MB | ~20-30s |
+| 150,000 | 3,000,000 | ~6GB | minutes |
+
+## Proposed Solutions
+
+### Option A: Lazy Loading per Conversation
+**Pros:** 90% memory reduction, only loads data when needed
+**Cons:** More database queries (one per conversation)
+**Effort:** Medium
+**Risk:** Low
+
+```rust
+fn get_bubble_data_for_composer(conn: &Connection, composer_id: &str) -> BubbleDataMap {
+    let pattern = format!("bubbleId:{}:%", composer_id);
+    conn.prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE ?")
+        .query_map([&pattern], |row| { ... })
+}
+```
+
+### Option B: Batch Loading
+**Pros:** Fewer queries than Option A, bounded memory
+**Cons:** More complex implementation
+**Effort:** High
+**Risk:** Medium
+
+Load bubble data in batches of 100 conversations at a time.
+
+### Option C: Keep Current (Accept Trade-off)
+**Pros:** No code changes, O(1) lookup amortizes cost
+**Cons:** Memory spike remains, doesn't scale
+**Effort:** None
+**Risk:** None (current behavior)
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 172-208, 429)
+
+**Components:**
+- `fetch_bubble_data()` function
+- `extract_from_db()` function
+
+## Acceptance Criteria
+
+- [ ] Memory usage during indexing stays under 100MB for 1500 conversations
+- [ ] Indexing time doesn't regress significantly
+- [ ] All 67 existing tests pass
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Performance Oracle agent | Memory spike documented |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26
+- Performance Oracle analysis

--- a/todos/002-completed-p2-filesystem-calls-in-workspace-extraction.md
+++ b/todos/002-completed-p2-filesystem-calls-in-workspace-extraction.md
@@ -1,0 +1,109 @@
+---
+status: completed
+priority: p2
+issue_id: "002"
+tags: [code-review, performance]
+dependencies: []
+---
+
+# P2: Filesystem Calls in Workspace Extraction Hot Path
+
+## Problem Statement
+
+The `extract_workspace_from_context()` function makes `is_file()` and `exists()` syscalls for each path when computing the common ancestor directory. These filesystem calls are unnecessary since we only need to compute the common path prefix from strings.
+
+**Why it matters:** Each syscall adds latency (~1-5ms). With 100 file references in a conversation, this adds 100-500ms per conversation during indexing.
+
+## Findings
+
+**Source:** Performance Oracle Agent, Code Simplicity Reviewer
+
+**Location:** `src/connectors/cursor.rs`, lines 364-376
+
+```rust
+let mut common = if first_path.is_file() || !first_path.exists() {  // syscall
+    first_path.parent()?.to_path_buf()
+} else {
+    first_path.clone()
+};
+
+for path in paths.iter().skip(1) {
+    let path_to_check = if path.is_file() || !path.exists() {  // syscall per path
+        path.parent().map(PathBuf::from)
+    } else {
+        Some(path.clone())
+    };
+    // ...
+}
+```
+
+**Evidence:**
+- `is_file()` and `exists()` are syscalls that hit the filesystem
+- Called for every path in fileSelections, folderSelections, etc.
+- Some conversations have 100+ file references
+- Paths come from JSON data - no need to verify they exist on disk
+
+## Proposed Solutions
+
+### Option A: Pure String-Based Path Comparison (Recommended)
+**Pros:** No I/O, fast, predictable performance
+**Cons:** May treat all paths as files (take parent dir)
+**Effort:** Low
+**Risk:** Low
+
+```rust
+fn extract_workspace_from_context(val: &Value) -> Option<PathBuf> {
+    let paths = Self::collect_file_paths(val);
+    if paths.is_empty() { return None; }
+
+    // Assume all paths are files, use parent directories
+    let mut common: Vec<_> = paths[0].parent()?.components().collect();
+    for path in &paths[1..] {
+        if let Some(parent) = path.parent() {
+            let components: Vec<_> = parent.components().collect();
+            common.truncate(
+                common.iter().zip(&components)
+                    .take_while(|(a, b)| a == b)
+                    .count()
+            );
+        }
+    }
+    (common.len() > 2).then(|| common.into_iter().collect())
+}
+```
+
+### Option B: Heuristic-Based (No Syscalls)
+**Pros:** More accurate file vs directory detection
+**Cons:** Slightly more complex
+**Effort:** Low
+**Risk:** Low
+
+Check if path has file extension to determine if it's a file, no syscalls needed.
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 364-408)
+
+**Components:**
+- `extract_workspace_from_context()` function
+
+## Acceptance Criteria
+
+- [ ] No filesystem syscalls in workspace extraction
+- [ ] Workspace extraction produces same results for test cases
+- [ ] All existing tests pass
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Performance Oracle agent | Syscalls in hot path |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26

--- a/todos/003-completed-p2-percent-decoding-utf8-bug.md
+++ b/todos/003-completed-p2-percent-decoding-utf8-bug.md
@@ -1,0 +1,112 @@
+---
+status: completed
+priority: p2
+issue_id: "003"
+tags: [code-review, bug, encoding]
+dependencies: []
+---
+
+# P2: Custom Percent-Decoding Has UTF-8 Bug
+
+## Problem Statement
+
+The `parse_file_uri()` function implements manual percent-decoding that only handles single-byte ASCII characters correctly. Multi-byte UTF-8 sequences (e.g., `%E4%B8%AD` for Chinese characters) will be corrupted.
+
+**Why it matters:** Users with non-ASCII characters in their file paths (international users, projects with Unicode names) will see garbled workspace paths.
+
+## Findings
+
+**Source:** Security Sentinel, Code Simplicity Reviewer, Pattern Recognition Specialist
+
+**Location:** `src/connectors/cursor.rs`, lines 252-273
+
+```rust
+if hex.len() == 2
+    && let Ok(byte) = u8::from_str_radix(&hex, 16)
+{
+    decoded.push(byte as char);  // BUG: treats byte as char directly
+    continue;
+}
+```
+
+**Evidence:**
+- `byte as char` only works for ASCII (0x00-0x7F)
+- For bytes 0x80-0xFF (first byte of UTF-8 sequences), this creates invalid characters
+- Example: `%E4%B8%AD` (Chinese "中") becomes three invalid chars instead of one valid char
+
+**Reproduction:**
+```rust
+// Input: "file:///Users/test/%E4%B8%AD%E6%96%87.txt"
+// Expected: "/Users/test/中文.txt"
+// Actual: "/Users/test/\u{e4}\u{b8}\u{ad}\u{e6}\u{96}\u{87}.txt" (garbled)
+```
+
+## Proposed Solutions
+
+### Option A: Use `urlencoding` Crate (Recommended)
+**Pros:** Correct UTF-8 handling, well-tested, 1 line of code
+**Cons:** Adds dependency
+**Effort:** Low
+**Risk:** Very Low
+
+```toml
+# Cargo.toml
+urlencoding = "2.1"
+```
+
+```rust
+fn parse_file_uri(uri: &str) -> Option<PathBuf> {
+    let path = uri.strip_prefix("file://")?;
+    let decoded = urlencoding::decode(path).ok()?;
+    Some(PathBuf::from(decoded.into_owned()))
+}
+```
+
+### Option B: Use `percent-encoding` Crate
+**Pros:** More control, widely used
+**Cons:** Slightly more verbose
+**Effort:** Low
+**Risk:** Very Low
+
+```rust
+use percent_encoding::percent_decode_str;
+let decoded = percent_decode_str(path).decode_utf8().ok()?;
+```
+
+### Option C: Fix Manual Implementation
+**Pros:** No new dependencies
+**Cons:** More code, easy to get wrong
+**Effort:** Medium
+**Risk:** Medium
+
+Collect bytes into a Vec<u8> first, then convert to String with `String::from_utf8`.
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 248-274)
+
+**Components:**
+- `parse_file_uri()` function
+
+## Acceptance Criteria
+
+- [ ] Paths with Chinese/Japanese/Korean characters decode correctly
+- [ ] Paths with emojis decode correctly
+- [ ] All existing tests pass
+- [ ] Add test for multi-byte UTF-8 decoding
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Security Sentinel | UTF-8 handling bug confirmed |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26
+- urlencoding crate: https://docs.rs/urlencoding

--- a/todos/004-completed-p3-code-duplication-path-extraction.md
+++ b/todos/004-completed-p3-code-duplication-path-extraction.md
@@ -1,0 +1,103 @@
+---
+status: completed
+priority: p3
+issue_id: "004"
+tags: [code-review, refactoring, dry]
+dependencies: []
+---
+
+# P3: Code Duplication in Path Extraction Loops
+
+## Problem Statement
+
+The `extract_workspace_from_context()` function has nearly identical code repeated 5 times for extracting paths from different JSON fields: `fileSelections`, `folderSelections`, `selections`, `newlyCreatedFiles`, and `newlyCreatedFolders`.
+
+**Why it matters:** Violates DRY principle, makes maintenance harder, ~50 lines could be reduced to ~15.
+
+## Findings
+
+**Source:** Pattern Recognition Specialist, Code Simplicity Reviewer
+
+**Location:** `src/connectors/cursor.rs`, lines 293-355
+
+```rust
+// Pattern repeated 5 times with minor variations:
+if let Some(selections) = context.get("fileSelections").and_then(|v| v.as_array()) {
+    for sel in selections {
+        if let Some(uri) = sel.get("uri")
+            && let Some(path) = extract_from_uri(uri)
+        {
+            paths.push(path);
+        }
+    }
+}
+
+// Nearly identical for folderSelections, selections...
+// Slightly different for newlyCreatedFiles, newlyCreatedFolders (handles string array too)
+```
+
+## Proposed Solutions
+
+### Option A: Helper Function with Key List
+**Pros:** Concise, maintainable
+**Cons:** Slightly less explicit
+**Effort:** Low
+**Risk:** Low
+
+```rust
+fn collect_file_paths(val: &Value) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let ctx = val.get("context");
+
+    // URI-based selections
+    for key in ["fileSelections", "folderSelections", "selections"] {
+        if let Some(arr) = ctx.and_then(|c| c.get(key)).and_then(|v| v.as_array()) {
+            paths.extend(arr.iter().filter_map(|s| extract_uri_path(s.get("uri")?)));
+        }
+    }
+
+    // Mixed format arrays (string or object with uri)
+    for key in ["newlyCreatedFiles", "newlyCreatedFolders"] {
+        if let Some(arr) = val.get(key).and_then(|v| v.as_array()) {
+            paths.extend(arr.iter().filter_map(|f|
+                f.as_str().map(PathBuf::from)
+                    .or_else(|| extract_uri_path(f.get("uri")?))
+            ));
+        }
+    }
+    paths
+}
+```
+
+### Option B: Keep Current (Explicit)
+**Pros:** Very explicit, easy to understand
+**Cons:** Duplicated code, harder to maintain
+**Effort:** None
+**Risk:** None
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 293-355)
+
+**LOC Reduction:** ~35 lines
+
+## Acceptance Criteria
+
+- [ ] All 5 extraction patterns consolidated into helper
+- [ ] All existing tests pass
+- [ ] No change in behavior
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Pattern Recognition agent | DRY violation |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26

--- a/todos/005-pending-p3-function-complexity-parse-composer-data.md
+++ b/todos/005-pending-p3-function-complexity-parse-composer-data.md
@@ -1,0 +1,109 @@
+---
+status: pending
+priority: p3
+issue_id: "005"
+tags: [code-review, refactoring, complexity]
+dependencies: []
+---
+
+# P3: Function Complexity - parse_composer_data is 163 Lines
+
+## Problem Statement
+
+The `parse_composer_data()` function is 163 lines long and handles 7 different responsibilities:
+1. JSON parsing
+2. Composer ID extraction
+3. Deduplication checking
+4. Message parsing (multiple formats)
+5. Title extraction
+6. Workspace extraction
+7. Conversation construction
+
+Additionally, it takes 7 parameters which makes it harder to test and maintain.
+
+**Why it matters:** Long functions with many responsibilities are harder to understand, test, and modify.
+
+## Findings
+
+**Source:** Pattern Recognition Specialist, Architecture Strategist
+
+**Location:** `src/connectors/cursor.rs`, lines 485-648
+
+```rust
+fn parse_composer_data(
+    key: &str,
+    value: &str,
+    db_path: &Path,
+    _since_ts: Option<i64>,  // Unused but kept for interface consistency
+    seen_ids: &mut HashSet<String>,
+    bubble_data: &BubbleDataMap,
+    workspace: Option<&PathBuf>,
+) -> Option<NormalizedConversation>
+```
+
+## Proposed Solutions
+
+### Option A: Extract Helper Functions
+**Pros:** Clearer separation of concerns, easier to test
+**Cons:** More functions to navigate
+**Effort:** Medium
+**Risk:** Low
+
+```rust
+// Extract these helpers:
+fn parse_messages_from_new_format(...) -> Vec<NormalizedMessage>
+fn parse_messages_from_tabs(...) -> Vec<NormalizedMessage>
+fn parse_messages_from_conversation_map(...) -> Vec<NormalizedMessage>
+fn extract_title(val: &Value, messages: &[NormalizedMessage]) -> Option<String>
+```
+
+### Option B: Use ParseContext Struct
+**Pros:** Reduces parameter count, cleaner API
+**Cons:** More indirection
+**Effort:** Medium
+**Risk:** Low
+
+```rust
+struct ParseContext<'a> {
+    db_path: &'a Path,
+    seen_ids: &'a mut HashSet<String>,
+    bubble_data: &'a BubbleDataMap,
+    workspace: Option<&'a PathBuf>,
+}
+```
+
+### Option C: Keep Current (Works)
+**Pros:** No refactoring risk
+**Cons:** Technical debt remains
+**Effort:** None
+**Risk:** None
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 485-648)
+
+**Metrics:**
+- Current: 163 lines, 7 parameters
+- Goal: <50 lines per function, <4 parameters
+
+## Acceptance Criteria
+
+- [ ] Main function <50 lines
+- [ ] Each helper has single responsibility
+- [ ] All existing tests pass
+- [ ] No change in behavior
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Architecture Strategist | Function too long |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26

--- a/todos/006-completed-p3-unbounded-path-collection.md
+++ b/todos/006-completed-p3-unbounded-path-collection.md
@@ -1,0 +1,81 @@
+---
+status: completed
+priority: p3
+issue_id: "006"
+tags: [code-review, performance, defensive]
+dependencies: []
+---
+
+# P3: Unbounded Path Collection in Workspace Extraction
+
+## Problem Statement
+
+The `extract_workspace_from_context()` function collects paths from JSON arrays without any limit. Some conversations may have hundreds of file selections, leading to unbounded memory growth and unnecessary processing.
+
+**Why it matters:** Pathological cases with 1000+ file references could cause performance issues. Once we have ~10 paths, additional paths don't meaningfully improve common ancestor accuracy.
+
+## Findings
+
+**Source:** Performance Oracle Agent
+
+**Location:** `src/connectors/cursor.rs`, lines 280-355
+
+```rust
+fn extract_workspace_from_context(val: &Value) -> Option<PathBuf> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    // No limit on paths collected...
+    for sel in selections {  // Could be 1000+ items
+        // ...
+        paths.push(path);
+    }
+}
+```
+
+## Proposed Solutions
+
+### Option A: Add Path Limit (Recommended)
+**Pros:** Simple, prevents pathological cases
+**Cons:** Might miss edge cases where later paths matter
+**Effort:** Very Low
+**Risk:** Very Low
+
+```rust
+const MAX_PATHS_FOR_WORKSPACE: usize = 10;
+
+for sel in selections.iter().take(MAX_PATHS_FOR_WORKSPACE) {
+    // ...
+}
+```
+
+### Option B: Early Termination When Confident
+**Pros:** Smarter, stops when common ancestor is stable
+**Cons:** More complex logic
+**Effort:** Medium
+**Risk:** Low
+
+Stop collecting paths once common ancestor stops changing for N iterations.
+
+## Recommended Action
+
+_To be filled during triage_
+
+## Technical Details
+
+**Affected Files:**
+- `src/connectors/cursor.rs` (lines 293-355)
+
+## Acceptance Criteria
+
+- [ ] Path collection limited to reasonable number (e.g., 10-20)
+- [ ] Workspace extraction still accurate for normal cases
+- [ ] All existing tests pass
+
+## Work Log
+
+| Date | Action | Outcome/Learning |
+|------|--------|------------------|
+| 2026-01-02 | Identified by Performance Oracle | Unbounded collection |
+
+## Resources
+
+- PR #26: https://github.com/Dicklesworthstone/coding_agent_session_search/pull/26


### PR DESCRIPTION
**Note: This was vibe coded! It works for me but I don't know rust so I can't vouch for the quality.**

## Summary

- Adds support for Cursor v0.40+ which stores chat data in a new `fullConversationHeadersOnly` format with separate bubble entries
- Fixes a bug where selecting a Cursor conversation in the TUI would show the wrong chat
- **NEW:** Extracts workspace path from conversation context (file references)
- **NEW:** Uses `lastUpdatedAt` for more accurate `ended_at` timestamps

## Changes

### Workspace Extraction (Two Methods)
1. **From workspaceStorage** (original approach): Reads `workspace.json` from `workspaceStorage/{hash}/` directories
2. **From conversation context** (new): Extracts file paths from `fileSelections`, `folderSelections`, `selections`, `newlyCreatedFiles`, and `newlyCreatedFolders` to find the common ancestor workspace directory

The second method is essential because Cursor stores ALL conversations in `globalStorage`, not in individual `workspaceStorage` databases. This enables workspace detection for ~32% of conversations (those that reference files).

**Note:** `newlyCreatedFiles` is an array of objects with `uri.fsPath`, not strings - fixed this to properly extract paths.

### Timestamp Improvements  
- Extracts `lastUpdatedAt` from Cursor conversation data
- Uses `lastUpdatedAt` → last message time → `createdAt` fallback chain for `ended_at`

### Previous Changes (v0.40+ format support)
- `composerData:{uuid}` now contains only headers with `bubbleId` references
- Actual message content stored separately in `bubbleId:{composerId}:{bubbleId}` keys
- Role encoded as numeric type (1=user, 2=assistant) instead of strings
- Fixed unique `source_path` per conversation

## Test plan

- [x] `cargo test --lib connectors::cursor` - 67 tests pass
- [x] `cargo clippy` - no warnings
- [x] Tested locally: 469 Cursor conversations now have workspace (32%, up from 0)