### PR TITLE
fix: pin base64 to >=0.21 for Engine API compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ crossterm = "*"
 dirs = "*"
 walkdir = "*"
 glob = "*"
-base64 = "*"
+base64 = ">=0.21"
 chrono = { version = "*", features = ["serde"] }
 semver = "*"
 tracing-appender = "*"


### PR DESCRIPTION
The code uses `base64::Engine` trait which is only available in base64 0.21+:
https://github.com/Dicklesworthstone/coding_agent_session_search/blob/f1d53f4afbb3b5eae8c5b8bce8b3fa96a6ee6adb/src/config.rs#L3

However, `Cargo.toml` specifies `base64 = "*"` which allows Cargo to resolve to older versions like 0.13.1 when other transitive dependencies pull them in.

## Context

This was discovered when packaging cass for [llm-agents.nix](https://github.com/numtide/llm-agents.nix). Package managers like Nix that resolve all dependencies deterministically can hit this version conflict where an older base64 gets selected.