### PR TITLE
Add missing tempfile dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ rand = "0.8"  # Pin to 0.8.x for rand_core 0.6.x compatibility with argon2/aes-g
 # QR code generation (optional, for recovery secret QR codes)
 qrcode = { version = "*", optional = true }
 image = { version = "*", optional = true, default-features = false, features = ["png"] }
+tempfile = "*"
 
 # macOS keychain access (optional, for ChatGPT decryption)
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
## Summary
- Adds `tempfile` crate to Cargo.toml dependencies

## Problem
`src/lib.rs` uses `tempfile::tempdir()` but crate not declared as direct dependency. Build-from-source fails when pre-built binary unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)