### PR TITLE
Filter out SUGGESTION MODE sessions from timeline and search

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12415,7 +12415,9 @@ fn run_timeline(
          JOIN agents a ON c.agent_id = a.id
          LEFT JOIN sources s ON c.source_id = s.id
          LEFT JOIN messages m ON m.conversation_id = c.id
-         WHERE c.started_at >= ?1 AND c.started_at <= ?2",
+         WHERE c.started_at >= ?1 AND c.started_at <= ?2
+           AND COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
+           AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'",
     );
 
     let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(start_ts), Box::new(end_ts)];

--- a/src/pages/fts.rs
+++ b/src/pages/fts.rs
@@ -228,7 +228,9 @@ pub fn build_fts5_search_sql(
 FROM {fts_table}
 JOIN messages m ON {fts_table}.rowid = m.id
 JOIN conversations c ON m.conversation_id = c.id
-WHERE {fts_table} MATCH ?"#
+WHERE {fts_table} MATCH ?
+    AND COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
+    AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'"#
     );
 
     if with_agent_filter {

--- a/src/pages_assets/database.js
+++ b/src/pages_assets/database.js
@@ -200,6 +200,8 @@ export function getRecentConversations(limit = 50) {
     return queryAll(`
         SELECT id, agent, workspace, title, source_path, started_at, ended_at, message_count
         FROM conversations
+        WHERE COALESCE(title, '') NOT LIKE '[SUGGESTION MODE%'
+          AND COALESCE(title, '') NOT LIKE 'SUGGESTION MODE%'
         ORDER BY started_at DESC
         LIMIT ?
     `, [limit]);
@@ -373,6 +375,8 @@ export function searchConversations(query, options = {}) {
         JOIN messages m ON ${ftsTable}.rowid = m.id
         JOIN conversations c ON m.conversation_id = c.id
         WHERE ${ftsTable} MATCH ?
+          AND COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
+          AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'
     `;
 
     const params = [escapedQuery];
@@ -407,6 +411,8 @@ export function getConversationsByAgent(agent, limit = 50) {
         SELECT id, agent, workspace, title, source_path, started_at, message_count
         FROM conversations
         WHERE agent = ?
+          AND COALESCE(title, '') NOT LIKE '[SUGGESTION MODE%'
+          AND COALESCE(title, '') NOT LIKE 'SUGGESTION MODE%'
         ORDER BY started_at DESC
         LIMIT ?
     `, [agent, limit]);
@@ -423,6 +429,8 @@ export function getConversationsByWorkspace(workspace, limit = 50) {
         SELECT id, agent, workspace, title, source_path, started_at, message_count
         FROM conversations
         WHERE workspace = ?
+          AND COALESCE(title, '') NOT LIKE '[SUGGESTION MODE%'
+          AND COALESCE(title, '') NOT LIKE 'SUGGESTION MODE%'
         ORDER BY started_at DESC
         LIMIT ?
     `, [workspace, limit]);
@@ -440,6 +448,8 @@ export function getConversationsByTimeRange(since, until, limit = 50) {
         SELECT id, agent, workspace, title, source_path, started_at, message_count
         FROM conversations
         WHERE started_at >= ? AND started_at <= ?
+          AND COALESCE(title, '') NOT LIKE '[SUGGESTION MODE%'
+          AND COALESCE(title, '') NOT LIKE 'SUGGESTION MODE%'
         ORDER BY started_at DESC
         LIMIT ?
     `, [since, until, limit]);

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1293,6 +1293,8 @@ impl SqliteStorage {
                 FROM conversations c
                 JOIN agents a ON c.agent_id = a.id
                 LEFT JOIN workspaces w ON c.workspace_id = w.id
+                WHERE COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
+                  AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'
                 ORDER BY c.started_at IS NULL, c.started_at DESC, c.id DESC
                 LIMIT ? OFFSET ?",
         )?;


### PR DESCRIPTION
## Problem

Claude Code's autocomplete feature generates "suggestion mode" prompts that get logged as separate sessions. These create significant noise in the timeline and search results:

```
11:54 🟣    0m │   3 msgs │ [SUGGESTION MODE: Suggest what the user
11:54 🟣    0m │   3 msgs │ [SUGGESTION MODE: Suggest what the user
11:53 🟣    0m │   3 msgs │ [SUGGESTION MODE: Suggest what the user
11:48 🟣    0m │   2 msgs │ [SUGGESTION MODE: Suggest what the user
11:40 🟣    0m │   2 msgs │ [SUGGESTION MODE: Suggest what the user
```

These are ephemeral autocomplete suggestions, not real coding sessions. They clutter the timeline and make it hard to find actual work.

## Solution

Filter these sessions at the query level while **preserving them in the database** for potential analysis. Sessions where the title starts with `[SUGGESTION MODE` or `SUGGESTION MODE` are excluded from display.

## Changes

| File | Function | Description |
|------|----------|-------------|
| `src/lib.rs` | `run_timeline()` | Filter timeline query |
| `src/pages/fts.rs` | `build_fts5_search_sql()` | Filter FTS search results |
| `src/storage/sqlite.rs` | `list_conversations()` | Filter session listing |
| `src/pages_assets/database.js` | 5 query functions | Filter web viewer queries |

## How to Reproduce

For maintainers/agents who want to implement this from scratch:

### 1. Filter the timeline query (`src/lib.rs`, ~line 12411)

Find the `run_timeline` function's SQL query and add these lines after `WHERE c.started_at >= ?1 AND c.started_at <= ?2`:

```sql
AND COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'
```

### 2. Filter FTS search (`src/pages/fts.rs`, ~line 217)

In `build_fts5_search_sql()`, add after `WHERE {fts_table} MATCH ?`:

```sql
AND COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'
```

### 3. Filter list_conversations (`src/storage/sqlite.rs`, ~line 1288)

In `list_conversations()`, add a WHERE clause before ORDER BY:

```sql
WHERE COALESCE(c.title, '') NOT LIKE '[SUGGESTION MODE%'
  AND COALESCE(c.title, '') NOT LIKE 'SUGGESTION MODE%'
```

### 4. Filter JavaScript queries (`src/pages_assets/database.js`)

Add the same filter to these 5 functions:
- `getRecentConversations()` (~line 199)
- `searchConversations()` (~line 341)
- `getConversationsByAgent()` (~line 405)
- `getConversationsByWorkspace()` (~line 421)
- `getConversationsByTimeRange()` (~line 438)

For each, add to the WHERE clause:
```sql
AND COALESCE(title, '') NOT LIKE '[SUGGESTION MODE%'
AND COALESCE(title, '') NOT LIKE 'SUGGESTION MODE%'
```

## Testing

```bash
# Before: timeline shows many SUGGESTION MODE entries
cass timeline --today | grep -c "SUGGESTION MODE"  # Many matches

# After: filtered out
cargo build --release
./target/release/cass timeline --today | grep -c "SUGGESTION MODE"  # 0 matches
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)