### PR TITLE
fix installer fallback when no releases exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ install.ps1 -EasyMode -Verify
 ```
 
 Installs the latest release by default. Pass `--version <tag>` / `-Version <tag>` to pin a specific version.
+If release artifacts are unavailable, the shell installer falls back to the latest git tag and builds from source.
+Source builds require a Rust toolchain with Edition 2024 support (`rustc`/`cargo` 1.85+).
+
+```bash
+# Force source build from a specific tag
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/coding_agent_session_search/main/install.sh?$(date +%s)" \
+  | bash -s -- --easy-mode --verify --version v0.1.64 --from-source
+```
 
 **Or via package managers:**
 

--- a/install.sh
+++ b/install.sh
@@ -28,16 +28,17 @@ err() { log "\033[0;31m✗\033[0m $*"; }
 
 resolve_version() {
   if [ -n "$VERSION" ]; then return 0; fi
-  local latest=""
+  local latest="" latest_json="" tags_json=""
   if command -v curl >/dev/null 2>&1; then
-    # Try 1: Fetch latest release tag from GitHub API
-    latest=$(curl -fsSL "https://api.github.com/repos/$OWNER/$REPO/releases/latest" 2>/dev/null \
-      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    # Try 1: Fetch latest release tag from GitHub API.
+    # Do not fail hard when releases/latest returns 404 (no releases yet).
+    latest_json=$(curl -sSL "https://api.github.com/repos/$OWNER/$REPO/releases/latest" 2>/dev/null || true)
+    latest=$(printf '%s\n' "$latest_json" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' || true)
     # Try 2: If no releases exist, fall back to latest git tag (sorted by version)
     if [ -z "$latest" ]; then
       warn "No GitHub releases found; falling back to latest git tag"
-      latest=$(curl -fsSL "https://api.github.com/repos/$OWNER/$REPO/tags?per_page=1" 2>/dev/null \
-        | grep '"name"' | head -1 | sed 's/.*"name": *"\([^"]*\)".*/\1/')
+      tags_json=$(curl -sSL "https://api.github.com/repos/$OWNER/$REPO/tags?per_page=1" 2>/dev/null || true)
+      latest=$(printf '%s\n' "$tags_json" | grep '"name"' | head -1 | sed 's/.*"name": *"\([^"]*\)".*/\1/' || true)
     fi
   fi
   if [ -n "$latest" ]; then


### PR DESCRIPTION
## Summary
- make `resolve_version` resilient when `/releases/latest` returns 404
- preserve fallback to latest git tag without tripping `set -euo pipefail`
- document source-build fallback and Rust 1.85+ requirement in README

## Repro
Running the documented one-liner currently exits early when the repo has tags but no GitHub release objects:

```bash
curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/coding_agent_session_search/main/install.sh?$(date +%s)" \
  | bash -s -- --easy-mode --verify
```

Before this change, the script could exit in `resolve_version` before printing an actionable error because `curl -f` failed in the `latest release` pipeline under `set -e`.

## Validation
- `bash -n install.sh`
- manual diff review of fallback behavior + README guidance
