### PR TITLE
feat: incremental semantic embedding in watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "advisory-lock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6caee7d48f930f9ad3fc9546f8cbf843365da0c5b0ca4eee1d1ac3dd12d8f93"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +292,7 @@ dependencies = [
  "franken-kernel 0.2.5",
  "getrandom 0.4.1",
  "hmac",
+ "io-uring",
  "libc",
  "nix 0.31.1",
  "parking_lot",
@@ -331,7 +342,6 @@ dependencies = [
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "tracing-subscriber",
  "visibility",
@@ -515,6 +525,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitpacking"
@@ -754,6 +767,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -761,6 +785,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -812,6 +849,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -922,6 +960,9 @@ dependencies = [
  "flate2",
  "franken-agent-detection",
  "frankensearch",
+ "fsqlite",
+ "fsqlite-error",
+ "fsqlite-types",
  "ftui",
  "ftui-extras",
  "ftui-runtime",
@@ -1143,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -2042,6 +2092,237 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fsqlite"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-core",
+ "fsqlite-error",
+ "fsqlite-ext-fts5",
+ "fsqlite-ext-json",
+ "fsqlite-ext-rtree",
+ "fsqlite-types",
+ "fsqlite-vfs",
+]
+
+[[package]]
+name = "fsqlite-ast"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-types",
+]
+
+[[package]]
+name = "fsqlite-btree"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-error",
+ "fsqlite-pager",
+ "fsqlite-types",
+ "hashbrown 0.14.5",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-core"
+version = "0.1.1"
+dependencies = [
+ "asupersync 0.2.5",
+ "blake3",
+ "fsqlite-ast",
+ "fsqlite-btree",
+ "fsqlite-error",
+ "fsqlite-ext-fts5",
+ "fsqlite-ext-json",
+ "fsqlite-func",
+ "fsqlite-mvcc",
+ "fsqlite-observability",
+ "fsqlite-pager",
+ "fsqlite-parser",
+ "fsqlite-planner",
+ "fsqlite-types",
+ "fsqlite-vdbe",
+ "fsqlite-vfs",
+ "fsqlite-wal",
+ "serde",
+ "serde_json",
+ "tracing",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "fsqlite-error"
+version = "0.1.1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fsqlite-ext-fts5"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-error",
+ "fsqlite-func",
+ "fsqlite-types",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-ext-json"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-error",
+ "fsqlite-func",
+ "fsqlite-types",
+ "json5",
+ "serde_json",
+]
+
+[[package]]
+name = "fsqlite-ext-rtree"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-error",
+ "fsqlite-types",
+]
+
+[[package]]
+name = "fsqlite-func"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-error",
+ "fsqlite-types",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-mvcc"
+version = "0.1.1"
+dependencies = [
+ "blake3",
+ "crossbeam-epoch",
+ "fsqlite-error",
+ "fsqlite-observability",
+ "fsqlite-pager",
+ "fsqlite-types",
+ "fsqlite-wal",
+ "nix 0.29.0",
+ "parking_lot",
+ "serde",
+ "smallvec",
+ "tracing",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "fsqlite-observability"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-types",
+ "parking_lot",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-pager"
+version = "0.1.1"
+dependencies = [
+ "argon2",
+ "chacha20poly1305",
+ "fsqlite-error",
+ "fsqlite-types",
+ "fsqlite-vfs",
+ "parking_lot",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "fsqlite-parser"
+version = "0.1.1"
+dependencies = [
+ "fsqlite-ast",
+ "fsqlite-error",
+ "fsqlite-types",
+ "memchr",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-planner"
+version = "0.1.1"
+dependencies = [
+ "blake3",
+ "fsqlite-ast",
+ "fsqlite-error",
+ "fsqlite-types",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-types"
+version = "0.1.1"
+dependencies = [
+ "bitflags 2.11.0",
+ "blake3",
+ "fsqlite-error",
+ "serde",
+ "smallvec",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "fsqlite-vdbe"
+version = "0.1.1"
+dependencies = [
+ "crossbeam-deque",
+ "fsqlite-ast",
+ "fsqlite-btree",
+ "fsqlite-error",
+ "fsqlite-func",
+ "fsqlite-mvcc",
+ "fsqlite-pager",
+ "fsqlite-parser",
+ "fsqlite-types",
+ "fsqlite-wal",
+ "smallvec",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-vfs"
+version = "0.1.2"
+dependencies = [
+ "advisory-lock",
+ "asupersync 0.2.5",
+ "fsqlite-error",
+ "fsqlite-observability",
+ "fsqlite-types",
+ "libc",
+ "nix 0.29.0",
+ "pollster",
+ "tracing",
+]
+
+[[package]]
+name = "fsqlite-wal"
+version = "0.1.1"
+dependencies = [
+ "asupersync 0.2.5",
+ "blake3",
+ "crc32c",
+ "fsqlite-error",
+ "fsqlite-types",
+ "fsqlite-vfs",
+ "parking_lot",
+ "serde",
+ "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3132,6 +3413,11 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3682,6 +3968,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +4105,17 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -4294,6 +4602,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
@@ -4704,6 +5025,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4807,6 +5171,23 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5154,7 +5535,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
 ]
@@ -6774,7 +7155,6 @@ name = "tru"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "clap_complete",
  "serde",
@@ -6796,6 +7176,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -7863,6 +8249,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,12 +126,10 @@ proptest = "*"
 serde_yaml = "*"
 rand = "0.10"
 rand_chacha = "0.10"
-# frankensqlite compat gate tests (bead 3vvqa) — COMMENTED OUT: fsqlite-mvcc requires
-# nightly features (peer_credentials_unix_socket, unix_socket_ancillary_data) which break
-# ALL test compilation on stable Rust. Re-enable when nightly toolchain is configured.
-# fsqlite = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite", features = ["fts5"] }
-# fsqlite-types = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite-types" }
-# fsqlite-error = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite-error" }
+# frankensqlite compat gate tests (bead 3vvqa) — nightly feature blocker resolved upstream
+fsqlite = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite", features = ["fts5"] }
+fsqlite-types = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite-types" }
+fsqlite-error = { version = "0.1.1", path = "../frankensqlite/crates/fsqlite-error" }
 
 [[bin]]
 name = "cass"

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1063,83 +1063,122 @@ pub fn run_index(
 
     // Semantic indexing (if enabled)
     if opts.semantic {
-        tracing::info!(embedder = %opts.embedder, "starting semantic indexing");
-
-        let semantic_indexer = SemanticIndexer::new(&opts.embedder, Some(&opts.data_dir))?;
-
-        // Fetch all messages with metadata from SQLite
-        let raw_messages = storage.fetch_messages_for_embedding()?;
-        tracing::info!(
-            message_count = raw_messages.len(),
-            "fetched messages for embedding"
-        );
-
-        // Convert to EmbeddingInput format
-        let embedding_inputs: Vec<EmbeddingInput> = raw_messages
-            .into_iter()
-            .filter_map(|msg| {
-                let role_u8 = match msg.role.as_str() {
-                    "user" => ROLE_USER,
-                    "agent" | "assistant" => ROLE_ASSISTANT,
-                    "system" => ROLE_SYSTEM,
-                    "tool" => ROLE_TOOL,
-                    _ => ROLE_USER, // default to user for unknown roles
-                };
-
-                let Some(message_id) = message_id_from_db(msg.message_id) else {
-                    tracing::warn!(
-                        raw_message_id = msg.message_id,
-                        "Skipping message with out-of-range id during semantic indexing"
-                    );
-                    return None;
-                };
-
-                Some(EmbeddingInput {
-                    message_id,
-                    created_at_ms: msg.created_at.unwrap_or(0),
-                    agent_id: saturating_u32_from_i64(msg.agent_id),
-                    workspace_id: saturating_u32_from_i64(msg.workspace_id.unwrap_or(0)),
-                    source_id: msg.source_id_hash,
-                    role: role_u8,
-                    chunk_idx: 0,
-                    content: msg.content,
+        // In watch mode, skip the expensive bulk re-embed if a vector index and
+        // watermark already exist.  The incremental path in the watch callback
+        // will pick up any new messages via WAL append.
+        //
+        // We check for any .fsvi file because the embedder's runtime ID
+        // (e.g. "minilm-384") differs from opts.embedder (e.g. "fastembed").
+        let vi_dir = opts.data_dir.join(crate::search::vector_index::VECTOR_INDEX_DIR);
+        let has_existing_index = vi_dir.is_dir()
+            && std::fs::read_dir(&vi_dir)
+                .map(|entries| {
+                    entries
+                        .filter_map(|e| e.ok())
+                        .any(|e| {
+                            e.path()
+                                .extension()
+                                .is_some_and(|ext| ext == "fsvi")
+                        })
                 })
-            })
-            .collect();
+                .unwrap_or(false);
+        let has_watermark = storage.get_last_embedded_message_id()?.is_some();
 
-        // Generate embeddings
-        let embedded_messages = semantic_indexer.embed_messages(&embedding_inputs)?;
-        tracing::info!(
-            embedded_count = embedded_messages.len(),
-            "generated embeddings"
-        );
-
-        if !embedded_messages.is_empty() {
-            let vector_index =
-                semantic_indexer.build_and_save_index(embedded_messages, &opts.data_dir)?;
-            let index_path = crate::search::vector_index::vector_index_path(
-                &opts.data_dir,
-                semantic_indexer.embedder_id(),
-            );
+        if opts.watch && has_existing_index && has_watermark {
             tracing::info!(
-                path = %index_path.display(),
-                embedder = semantic_indexer.embedder_id(),
-                "saved semantic vector index"
+                dir = %vi_dir.display(),
+                "skipping bulk semantic re-embed (existing index + watermark found); \
+                 incremental watch callback will handle new messages"
+            );
+        } else {
+            tracing::info!(embedder = %opts.embedder, "starting semantic indexing");
+
+            let semantic_indexer =
+                SemanticIndexer::new(&opts.embedder, Some(&opts.data_dir))?;
+
+            // Fetch all messages with metadata from SQLite
+            let raw_messages = storage.fetch_messages_for_embedding()?;
+            tracing::info!(
+                message_count = raw_messages.len(),
+                "fetched messages for embedding"
             );
 
-            // Build HNSW index for approximate nearest neighbor search (if enabled)
-            if opts.build_hnsw {
-                let hnsw_path = semantic_indexer.build_hnsw_index(
-                    &vector_index,
+            // Convert to EmbeddingInput format
+            let embedding_inputs: Vec<EmbeddingInput> = raw_messages
+                .into_iter()
+                .filter_map(|msg| {
+                    let role_u8 = match msg.role.as_str() {
+                        "user" => ROLE_USER,
+                        "agent" | "assistant" => ROLE_ASSISTANT,
+                        "system" => ROLE_SYSTEM,
+                        "tool" => ROLE_TOOL,
+                        _ => ROLE_USER, // default to user for unknown roles
+                    };
+
+                    let Some(message_id) = message_id_from_db(msg.message_id) else {
+                        tracing::warn!(
+                            raw_message_id = msg.message_id,
+                            "Skipping message with out-of-range id during semantic indexing"
+                        );
+                        return None;
+                    };
+
+                    Some(EmbeddingInput {
+                        message_id,
+                        created_at_ms: msg.created_at.unwrap_or(0),
+                        agent_id: saturating_u32_from_i64(msg.agent_id),
+                        workspace_id: saturating_u32_from_i64(
+                            msg.workspace_id.unwrap_or(0),
+                        ),
+                        source_id: msg.source_id_hash,
+                        role: role_u8,
+                        chunk_idx: 0,
+                        content: msg.content,
+                    })
+                })
+                .collect();
+
+            // Generate embeddings
+            let embedded_messages =
+                semantic_indexer.embed_messages(&embedding_inputs)?;
+            tracing::info!(
+                embedded_count = embedded_messages.len(),
+                "generated embeddings"
+            );
+
+            if !embedded_messages.is_empty() {
+                let vector_index = semantic_indexer
+                    .build_and_save_index(embedded_messages, &opts.data_dir)?;
+                let saved_path = crate::search::vector_index::vector_index_path(
                     &opts.data_dir,
-                    None, // Use default M
-                    None, // Use default ef_construction
-                )?;
-                tracing::info!(
-                    path = %hnsw_path.display(),
-                    embedder = semantic_indexer.embedder_id(),
-                    "saved HNSW index for approximate search"
+                    semantic_indexer.embedder_id(),
                 );
+                tracing::info!(
+                    path = %saved_path.display(),
+                    embedder = semantic_indexer.embedder_id(),
+                    "saved semantic vector index"
+                );
+
+                // Build HNSW index for approximate nearest neighbor search (if enabled)
+                if opts.build_hnsw {
+                    let hnsw_path = semantic_indexer.build_hnsw_index(
+                        &vector_index,
+                        &opts.data_dir,
+                        None, // Use default M
+                        None, // Use default ef_construction
+                    )?;
+                    tracing::info!(
+                        path = %hnsw_path.display(),
+                        embedder = semantic_indexer.embedder_id(),
+                        "saved HNSW index for approximate search"
+                    );
+                }
+            }
+
+            // Set watermark so incremental watch-mode embedding only sees new messages
+            if let Some(last_input) = embedding_inputs.last() {
+                storage
+                    .set_last_embedded_message_id(last_input.message_id as i64)?;
             }
         }
     }
@@ -1167,6 +1206,20 @@ pub fn run_index(
         let storage = Arc::new(Mutex::new(storage));
         let t_index = Arc::new(Mutex::new(t_index));
 
+        // Semantic embedding cooldown state for watch mode.
+        // The initial pass already embedded everything, so we start the clock
+        // from now — the cooldown must elapse before the first incremental pass.
+        let semantic_enabled = opts.semantic;
+        let embedder_id = opts.embedder.clone();
+        let data_dir_for_semantic = opts.data_dir.clone();
+        let semantic_cooldown = Duration::from_secs(
+            std::env::var("CASS_WATCH_SEMANTIC_COOLDOWN_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(60),
+        );
+        let last_semantic_embed = Arc::new(Mutex::new(Instant::now()));
+
         // Initialize stale detector for watch mode
         let stale_detector = Arc::new(StaleDetector::from_env());
         let stale_config = StaleConfig::from_env();
@@ -1192,6 +1245,7 @@ pub fn run_index(
             event_channel,
             stale_detector,
             move |paths, roots, is_rebuild| {
+                let indexed;
                 if is_rebuild {
                     if let Ok(mut g) = state.lock() {
                         g.clear();
@@ -1202,7 +1256,7 @@ pub fn run_index(
                     // For rebuild, trigger reindex on all active roots
                     let all_root_paths: Vec<PathBuf> =
                         roots.iter().map(|(_, root)| root.path.clone()).collect();
-                    let indexed = reindex_paths(
+                    indexed = reindex_paths(
                         &opts_clone,
                         all_root_paths,
                         roots,
@@ -1212,9 +1266,9 @@ pub fn run_index(
                         true,
                     );
                     // Record result to stale detector
-                    detector_clone.record_scan(indexed.unwrap_or(0));
+                    detector_clone.record_scan(indexed.as_ref().copied().unwrap_or(0));
                 } else {
-                    let indexed = reindex_paths(
+                    indexed = reindex_paths(
                         &opts_clone,
                         paths,
                         roots,
@@ -1224,7 +1278,7 @@ pub fn run_index(
                         false,
                     );
                     // Record result to stale detector
-                    detector_clone.record_scan(indexed.unwrap_or(0));
+                    detector_clone.record_scan(indexed.as_ref().copied().unwrap_or(0));
 
                     // Merge Tantivy segments if idle conditions are met.
                     // Without this, each reindex_paths() commit creates a new
@@ -1232,9 +1286,35 @@ pub fn run_index(
                     // continuous watch mode operation. The cooldown logic inside
                     // optimize_if_idle() (300s, 4-segment threshold) prevents
                     // over-merging. See issue #87.
-                    if let Ok(mut guard) = t_index.lock() {
-                        if let Err(e) = guard.optimize_if_idle() {
-                            tracing::warn!(error = %e, "segment merge failed during watch");
+                    if let Ok(mut guard) = t_index.lock()
+                        && let Err(e) = guard.optimize_if_idle()
+                    {
+                        tracing::warn!(error = %e, "segment merge failed during watch");
+                    }
+                }
+
+                // Incremental semantic embedding with cooldown
+                if semantic_enabled && indexed.as_ref().copied().unwrap_or(0) > 0 {
+                    let should_embed = last_semantic_embed
+                        .lock()
+                        .map(|t| t.elapsed() >= semantic_cooldown)
+                        .unwrap_or(false);
+                    if should_embed {
+                        match incremental_semantic_embed(
+                            &embedder_id,
+                            &data_dir_for_semantic,
+                            storage.clone(),
+                        ) {
+                            Ok(0) => {} // no new messages to embed
+                            Ok(n) => {
+                                tracing::info!(count = n, "incremental semantic embedding complete");
+                                if let Ok(mut t) = last_semantic_embed.lock() {
+                                    *t = Instant::now();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "incremental semantic embedding failed");
+                            }
                         }
                     }
                 }
@@ -2316,6 +2396,95 @@ pub mod persist {
             other => MessageRole::Other(other.to_string()),
         }
     }
+}
+
+/// Perform incremental semantic embedding for messages added since the last
+/// watermark. Loads the ONNX model, embeds the batch, appends to the existing
+/// FSVI index via WAL, and updates the watermark. The `SemanticIndexer` (and
+/// its model) is dropped at the end of this call.
+fn incremental_semantic_embed(
+    embedder: &str,
+    data_dir: &Path,
+    storage: Arc<Mutex<SqliteStorage>>,
+) -> Result<usize> {
+    // 1. Read watermark
+    let watermark = storage
+        .lock()
+        .map_err(|e| anyhow::anyhow!("lock storage for watermark read: {e}"))?
+        .get_last_embedded_message_id()?
+        .unwrap_or(0);
+
+    // 2. Fetch new messages since watermark
+    let raw_messages = storage
+        .lock()
+        .map_err(|e| anyhow::anyhow!("lock storage for message fetch: {e}"))?
+        .fetch_messages_for_embedding_since(watermark)?;
+
+    if raw_messages.is_empty() {
+        return Ok(0);
+    }
+
+    tracing::info!(
+        since_id = watermark,
+        count = raw_messages.len(),
+        "incremental semantic: fetched new messages"
+    );
+
+    // 3. Convert to EmbeddingInput (same mapping as initial pass)
+    let embedding_inputs: Vec<EmbeddingInput> = raw_messages
+        .into_iter()
+        .filter_map(|msg| {
+            let role_u8 = match msg.role.as_str() {
+                "user" => ROLE_USER,
+                "agent" | "assistant" => ROLE_ASSISTANT,
+                "system" => ROLE_SYSTEM,
+                "tool" => ROLE_TOOL,
+                _ => ROLE_USER,
+            };
+
+            let Some(message_id) = message_id_from_db(msg.message_id) else {
+                tracing::warn!(
+                    raw_message_id = msg.message_id,
+                    "Skipping message with out-of-range id during incremental semantic indexing"
+                );
+                return None;
+            };
+
+            Some(EmbeddingInput {
+                message_id,
+                created_at_ms: msg.created_at.unwrap_or(0),
+                agent_id: saturating_u32_from_i64(msg.agent_id),
+                workspace_id: saturating_u32_from_i64(msg.workspace_id.unwrap_or(0)),
+                source_id: msg.source_id_hash,
+                role: role_u8,
+                chunk_idx: 0,
+                content: msg.content,
+            })
+        })
+        .collect();
+
+    if embedding_inputs.is_empty() {
+        return Ok(0);
+    }
+
+    // 4. Load model, embed, append
+    let semantic_indexer = SemanticIndexer::new(embedder, Some(data_dir))?;
+    let max_id = embedding_inputs
+        .iter()
+        .map(|e| e.message_id)
+        .max()
+        .unwrap_or(0);
+
+    let embedded = semantic_indexer.embed_messages(&embedding_inputs)?;
+    let count = semantic_indexer.append_to_index(embedded, data_dir)?;
+
+    // 5. Update watermark
+    storage
+        .lock()
+        .map_err(|e| anyhow::anyhow!("lock storage for watermark write: {e}"))?
+        .set_last_embedded_message_id(max_id as i64)?;
+
+    Ok(count)
 }
 
 #[cfg(test)]

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -274,6 +274,58 @@ impl SemanticIndexer {
             .map_err(|err| anyhow::anyhow!("open fsvi index failed: {err}"))
     }
 
+    /// Append new embeddings to an existing FSVI index via the WAL.
+    ///
+    /// Used for incremental semantic indexing in watch mode. Opens the
+    /// existing index, appends a batch of new embeddings, and compacts if
+    /// the WAL has grown large enough.
+    ///
+    /// Returns the number of entries appended.
+    pub fn append_to_index(
+        &self,
+        embedded_messages: impl IntoIterator<Item = EmbeddedMessage>,
+        data_dir: &Path,
+    ) -> Result<usize> {
+        let index_path = vector_index_path(data_dir, self.embedder_id());
+        let mut index = FsVectorIndex::open(&index_path)
+            .map_err(|err| anyhow::anyhow!("open fsvi index for append failed: {err}"))?;
+
+        let entries: Vec<(String, Vec<f32>)> = embedded_messages
+            .into_iter()
+            .map(|em| {
+                let doc_id = SemanticDocId {
+                    message_id: em.message_id,
+                    chunk_idx: em.chunk_idx,
+                    agent_id: em.agent_id,
+                    workspace_id: em.workspace_id,
+                    source_id: em.source_id,
+                    role: em.role,
+                    created_at_ms: em.created_at_ms,
+                    content_hash: Some(em.content_hash),
+                }
+                .to_doc_id_string();
+                (doc_id, em.embedding)
+            })
+            .collect();
+
+        let count = entries.len();
+        if count == 0 {
+            return Ok(0);
+        }
+
+        index
+            .append_batch(&entries)
+            .map_err(|err| anyhow::anyhow!("append_batch failed: {err}"))?;
+
+        if index.needs_compaction() {
+            index
+                .compact()
+                .map_err(|err| anyhow::anyhow!("compaction failed: {err}"))?;
+        }
+
+        Ok(count)
+    }
+
     /// Build and save an HNSW index for approximate nearest neighbor search.
     ///
     /// This creates an HNSW graph structure from the existing VectorIndex,

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -2680,6 +2680,46 @@ impl SqliteStorage {
         Ok(out)
     }
 
+    /// Fetch messages for embedding that were inserted after `since_id`.
+    /// Used for incremental semantic indexing in watch mode.
+    pub fn fetch_messages_for_embedding_since(
+        &self,
+        since_id: i64,
+    ) -> Result<Vec<MessageForEmbedding>> {
+        let mut stmt = self.conn.prepare(
+            r"SELECT m.id, m.created_at, c.agent_id, c.workspace_id, c.source_id, m.role, m.content
+              FROM messages m
+              JOIN conversations c ON m.conversation_id = c.id
+              WHERE m.id > ?1
+              ORDER BY m.id",
+        )?;
+
+        let rows = stmt.query_map(params![since_id], |row| {
+            let source_id_str: String = row
+                .get::<_, Option<String>>(4)?
+                .unwrap_or_else(|| "local".to_string());
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(source_id_str.as_bytes());
+            let source_id_hash = hasher.finalize();
+
+            Ok(MessageForEmbedding {
+                message_id: row.get(0)?,
+                created_at: row.get(1)?,
+                agent_id: row.get(2)?,
+                workspace_id: row.get(3)?,
+                source_id_hash,
+                role: row.get(5)?,
+                content: row.get(6)?,
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
     /// Insert or update an embedding job, returning the job ID.
     pub fn upsert_embedding_job(
         &self,
@@ -2828,6 +2868,34 @@ impl SqliteStorage {
         self.conn.execute(
             "INSERT OR REPLACE INTO meta(key, value) VALUES('last_indexed_at', ?)",
             params![ts.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Get the watermark for incremental semantic embedding.
+    /// Returns the highest message id that has been embedded, or None if no
+    /// embedding pass has been recorded yet.
+    pub fn get_last_embedded_message_id(&self) -> Result<Option<i64>> {
+        let id: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'last_embedded_message_id'",
+                [],
+                |row| {
+                    let s: String = row.get(0)?;
+                    Ok(s.parse().ok())
+                },
+            )
+            .optional()?
+            .flatten();
+        Ok(id)
+    }
+
+    /// Set the watermark for incremental semantic embedding.
+    pub fn set_last_embedded_message_id(&mut self, id: i64) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES('last_embedded_message_id', ?)",
+            params![id.to_string()],
         )?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **Incremental semantic embedding in watch mode**: When `cass index --watch --semantic` runs, new messages discovered by the file watcher now receive semantic embeddings via WAL-based append, instead of only being indexed lexically.
- **Cooldown-based batching** (default 60s, configurable via `CASS_WATCH_SEMANTIC_COOLDOWN_SECS`): The ONNX model loads once per cooldown cycle, embeds all accumulated new messages in a single batch, then is dropped — avoiding constant model load/unload every 2-5s callback.
- **Watch startup optimization**: Skips the expensive bulk re-embed when a vector index and watermark already exist, preventing OOM on memory-constrained systems.

## Changes

| File | Change |
|------|--------|
| `src/indexer/semantic.rs` | Add `append_to_index()` for WAL-based incremental vector index updates |
| `src/storage/sqlite.rs` | Add watermark methods (`get/set_last_embedded_message_id`) and `fetch_messages_for_embedding_since()` |
| `src/indexer/mod.rs` | Wire `incremental_semantic_embed()` + cooldown into watch callback; skip bulk re-embed on watch startup when index exists; set watermark after initial pass |
| `Cargo.toml` | Re-enable frankensqlite dev-dependencies (nightly blocker resolved upstream) |

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (2797/2798 pass, 1 pre-existing flaky perf test)
- [x] Live manual test: `cass index --watch --semantic` with 15s cooldown — confirmed incremental cycles fire (284 messages on first cycle, 2 on second), WAL file created, semantic search finds new content from the active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)