### PR TITLE
feat: implement MarkdownExporter for session results

### DIFF
--- a/src/export/markdown.rs
+++ b/src/export/markdown.rs
@@ -1,0 +1,12 @@
+pub struct MarkdownExporter;
+
+impl MarkdownExporter {
+    /// Exports session search results to a structured Markdown document.
+    pub fn export(sessions: Vec<String>, output_path: &str) -> std::io::Result<()> {
+        let mut content = String::from("# Agent Session Search Results\n\n");
+        for session in sessions {
+            content.push_str(&format!("## Session\n{}\n\n", session));
+        }
+        std::fs::write(output_path, content)
+    }
+}


### PR DESCRIPTION
This PR adds a `MarkdownExporter` to the session search tool, allowing users to save and share their indexed agent history in a structured, readable format.

### Changes:
- Added Rust-based Markdown generation logic.
- Support for exporting multiple search results to a single file.
- Enhances usability for audit and documentation workflows.

/claim #export