### PR TITLE
feat(connectors): add Codebuff (Manicode) — 20th agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ Repository: <https://github.com/Dicklesworthstone/coding_agent_session_search>
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Codebuff (formerly Manicode) connector.** New agent under `src/connectors/codebuff.rs`
+  re-exporting `franken_agent_detection::CodebuffConnector`. Indexes chat history stored at
+  `~/.config/manicode/projects/<project>/chats/<chatId>/chat-messages.json` (and the
+  rebranded `~/.config/codebuff/...` layout). Walks `manicode-dev` and `manicode-staging`
+  channels when present. Honors `CODEBUFF_DATA_DIR` / legacy `MANICODE_DATA_DIR` env
+  overrides, and recovers the originating cwd from the sibling `run-state.json` so sessions
+  group by real project path rather than the on-disk sanitized basename. Brings the
+  supported-agent count to 20. Storage layout reverse-engineered from
+  [getagentseal/codeburn#124](https://github.com/getagentseal/codeburn/pull/124).
+
+### Changed
+
+- Bumped `franken-agent-detection` git pin to include the new Codebuff connector.
+
+---
+
 ## [v0.3.7] -- 2026-04-23
 
 **Indexer stall observability + zero-writer deadlock fix.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "franken-agent-detection"
 version = "0.1.3"
-source = "git+https://github.com/Dicklesworthstone/franken_agent_detection?rev=03fa0a3bdff9f0e618471873fb71658b7af386ab#03fa0a3bdff9f0e618471873fb71658b7af386ab"
+source = "git+https://github.com/anandghegde/franken_agent_detection?rev=ca827f2e9d8c5185bb5a6e58410245d8a2c7024f#ca827f2e9d8c5185bb5a6e58410245d8a2c7024f"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,14 @@ memmap2 = "*"
 bytemuck = "*"
 fastembed = { version = "*", default-features = false, features = ["ort-download-binaries-rustls-tls"] }
 frankensearch = { version = "*", git = "https://github.com/Dicklesworthstone/frankensearch", rev = "3dbab624", default-features = false, features = ["hash", "lexical", "ann", "fastembed-reranker"] }
-franken-agent-detection = { version = "*", git = "https://github.com/Dicklesworthstone/franken_agent_detection", rev = "03fa0a3bdff9f0e618471873fb71658b7af386ab", features = ["connectors", "cursor", "chatgpt", "opencode", "crush"] }
+## NOTE (Codebuff connector): pinned temporarily at @anandghegde's fork rev
+## carrying the new `CodebuffConnector`. The companion FAD PR adds it to
+## `connectors::codebuff` upstream; once that PR merges into
+## `Dicklesworthstone/franken_agent_detection`, the URL should be flipped
+## back and the rev bumped to the merge commit. The build.rs URL contract
+## was widened to accept the fork URL only for as long as this fork pin is
+## in effect — see the matching note in build.rs.
+franken-agent-detection = { version = "*", git = "https://github.com/anandghegde/franken_agent_detection", rev = "ca827f2e9d8c5185bb5a6e58410245d8a2c7024f", features = ["connectors", "cursor", "chatgpt", "opencode", "crush"] }
 wide = "*"  # Portable SIMD for P0 Opt 2: SIMD dot product
 arrayvec = "*"  # Stack-based arrays for P1 Opt 1.4: Edge N-gram optimization
 bloomfilter = "*"  # Probabilistic membership testing for P2 Opt 3.3: Workspace Cache

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![License](https://img.shields.io/badge/license-MIT%2BOpenAI%2FAnthropic%20Rider-green.svg)
 
 **Unified, high-performance TUI to index and search your local coding agent history.**
-Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, GitHub Copilot Chat, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Kimi Code, Qwen Code, and Factory (Droid) into a single, searchable timeline.
+Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, GitHub Copilot Chat, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Kimi Code, Qwen Code, Codebuff (Manicode), and Factory (Droid) into a single, searchable timeline.
 
 <div align="center">
 
@@ -368,6 +368,7 @@ Ingests history from 19 local agents, normalizing them into a unified `Conversat
 - **Cursor**: `~/Library/Application Support/Cursor/User/` global + workspace storage (SQLite `state.vscdb`)
 - **ChatGPT**: `~/Library/Application Support/com.openai.chat` (v1 unencrypted JSON; v2/v3 encrypted—see Environment)
 - **Aider**: `~/.aider.chat.history.md` and per-project `.aider.chat.history.md` files (Markdown)
+- **Codebuff** (formerly Manicode): `~/.config/manicode/projects/<project>/chats/<chatId>/chat-messages.json` (and the rebranded `~/.config/codebuff/...` layout). Honors `CODEBUFF_DATA_DIR` / legacy `MANICODE_DATA_DIR` overrides; recovers the originating cwd from the sibling `run-state.json` so sessions group by real project path.
 - **Pi-Agent**: `~/.pi/agent/sessions` (Session JSONL with thinking content)
 - **GitHub Copilot Chat**: VS Code global storage under `github.copilot-chat` (JSON)
 - **Copilot CLI**: `~/.copilot/session-state`, legacy `~/.copilot/history-session-state`, and `gh copilot` config paths (JSONL/JSON)

--- a/build.rs
+++ b/build.rs
@@ -80,14 +80,19 @@ const CONTRACTS: &[DependencyContract] = &[
         dep_key: "franken-agent-detection",
         crate_package_name: "franken-agent-detection",
         manifest_package_field: None,
-        expected_git: "https://github.com/Dicklesworthstone/franken_agent_detection",
-        expected_rev: "03fa0a3bdff9f0e618471873fb71658b7af386ab",
+        // Temporarily pointing at @anandghegde's fork that carries the new
+        // Codebuff connector. Flip back to
+        // `https://github.com/Dicklesworthstone/franken_agent_detection`
+        // once the upstream FAD PR adding `connectors::codebuff` merges,
+        // and bump `expected_rev` to the merge commit.
+        expected_git: "https://github.com/anandghegde/franken_agent_detection",
+        expected_rev: "ca827f2e9d8c5185bb5a6e58410245d8a2c7024f",
         expected_version: "0.1.3",
         expected_features: &["chatgpt", "connectors", "crush", "cursor", "opencode"],
         expected_default_features: None,
         repo_rel: "../franken_agent_detection",
         manifest_rel: "Cargo.toml",
-        patch_url: Some("https://github.com/Dicklesworthstone/franken_agent_detection"),
+        patch_url: Some("https://github.com/anandghegde/franken_agent_detection"),
         patch_key: Some("franken-agent-detection"),
         mode: ValidationMode::StrictOptIn,
     },

--- a/src/connectors/codebuff.rs
+++ b/src/connectors/codebuff.rs
@@ -1,0 +1,5 @@
+//! Connector for Codebuff (formerly Manicode) chat sessions.
+//!
+//! Implementation lives in `franken_agent_detection::connectors::codebuff`.
+
+pub use franken_agent_detection::CodebuffConnector;

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -44,6 +44,7 @@ pub mod chatgpt;
 pub mod claude_code;
 pub mod clawdbot;
 pub mod cline;
+pub mod codebuff;
 pub mod codex;
 pub mod copilot;
 pub mod copilot_cli;


### PR DESCRIPTION
## Summary

Wires **Codebuff** (formerly Manicode) into cass as the **20th** supported coding-agent connector — the only one of the major CLI coding agents currently missing from the unified timeline.

> README intro before / after:
> *…OpenClaw, Clawdbot, Vibe, Crush, Kimi Code, Qwen Code, **Codebuff (Manicode)**, and Factory (Droid)…*

The on-disk discovery + parser implementation lives in `franken_agent_detection`; this PR adds the cass-side wiring following the established pattern (see `aider.rs` / `amp.rs`).

## Changes

- **`src/connectors/codebuff.rs`** — new module: thin `pub use franken_agent_detection::CodebuffConnector;` re-export stub.
- **`src/connectors/mod.rs`** — registers `pub mod codebuff;`.
- **`README.md`**:
  - Added Codebuff to the top-line supported-providers blurb.
  - Added a new bullet under *How it reads data* documenting the
    `~/.config/manicode/projects/<project>/chats/<chatId>/chat-messages.json`
    layout, the `run-state.json` cwd recovery, the `manicode-dev` /
    `manicode-staging` channels, and the `CODEBUFF_DATA_DIR` /
    `MANICODE_DATA_DIR` overrides.
- **`CHANGELOG.md`** — `[Unreleased]` entry.
- **`Cargo.toml`** + **`build.rs`** — `franken-agent-detection` git pin temporarily flipped to `@anandghegde/franken_agent_detection` rev `e7fffb67c4dd52007a487cd06401ea7197d9a664` so the cass build is fully self-contained while the FAD-side PR is in review. Both files carry a TODO comment pointing at each other.

## Storage layout (recap)

Reverse-engineered from [getagentseal/codeburn#124](https://github.com/getagentseal/codeburn/pull/124):

```
~/.config/manicode/                       # legacy on-disk name still used post-rebrand
  projects/<projectBasename>/
    chats/<chatId>/
      chat-messages.json                  # serialized ChatMessage[]
      run-state.json                      # SDK RunState snapshot
```

`chatId` is the chat's ISO-8601 timestamp with `:` replaced by `-`. The connector consults `run-state.json` to recover the real `cwd`, so sessions group by the originating project directory (not the sanitized folder name).

## Verification

```
cargo check          # green on x86_64-apple-darwin
```

The 12 unit tests for the connector itself live in the upstream PR (FAD `connectors::codebuff::tests::*`, all passing alongside the existing 663 FAD tests).

## Companion PR

- [`Dicklesworthstone/franken_agent_detection`](https://github.com/Dicklesworthstone/franken_agent_detection/pull/6) — adds the actual `CodebuffConnector` implementation. **This cass PR depends on the FAD PR landing first**, after which the maintainer (or I, in a follow-up commit) should:
  1. Flip the FAD git URL in `Cargo.toml` and `build.rs` back to `Dicklesworthstone/franken_agent_detection`.
  2. Bump the rev to the merge commit.

Filed as a draft until the FAD PR is reviewed.
