### PR TITLE
fix(indexer): skip semantic parent directory sync on Windows

### DIFF
--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -490,6 +490,7 @@ fn semantic_shard_ann_index_path(
         .join(format!("shard-{shard_index:05}.chsw"))
 }
 
+#[cfg(not(windows))]
 fn sync_parent_directory(path: &Path) -> Result<()> {
     let Some(parent) = path.parent() else {
         return Ok(());
@@ -499,6 +500,11 @@ fn sync_parent_directory(path: &Path) -> Result<()> {
     directory
         .sync_all()
         .with_context(|| format!("syncing parent directory {}", parent.display()))
+}
+
+#[cfg(windows)]
+fn sync_parent_directory(_path: &Path) -> Result<()> {
+    Ok(())
 }
 
 fn semantic_doc_id_for_embedded(embedded: &EmbeddedMessage) -> String {


### PR DESCRIPTION
## Summary
- Mirror the existing Windows-safe `sync_parent_directory` split in the semantic backfill path.
- Keep parent directory `sync_all()` on non-Windows, but make it a no-op on Windows where opening directory handles fails.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo check --lib` (blocked locally: OpenSSL build failed after disk pressure; retry with `OPENSSL_NO_VENDOR=1` then required missing `pkg-config`/system OpenSSL headers)

Fixes #216
