### PR TITLE
feat(connectors): enable Hermes Agent connector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ memmap2 = "*"
 bytemuck = "*"
 fastembed = { version = "*", default-features = false, features = ["ort-download-binaries-rustls-tls"] }
 frankensearch = { version = "*", git = "https://github.com/Dicklesworthstone/frankensearch", rev = "831b3b13", default-features = false, features = ["hash", "lexical", "ann", "fastembed-reranker"] }
-franken-agent-detection = { version = "*", git = "https://github.com/Dicklesworthstone/franken_agent_detection", rev = "7e288f493631020a4660443c5ad8fc7d4e49faa7", features = ["connectors", "cursor", "chatgpt", "opencode", "crush"] }
+franken-agent-detection = { version = "*", git = "https://github.com/Dicklesworthstone/franken_agent_detection", rev = "7e288f493631020a4660443c5ad8fc7d4e49faa7", features = ["connectors", "cursor", "chatgpt", "opencode", "crush", "hermes"] }
 wide = "*"  # Portable SIMD for P0 Opt 2: SIMD dot product
 arrayvec = "*"  # Stack-based arrays for P1 Opt 1.4: Edge N-gram optimization
 bloomfilter = "*"  # Probabilistic membership testing for P2 Opt 3.3: Workspace Cache

--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ const CONTRACTS: &[DependencyContract] = &[
         expected_git: "https://github.com/Dicklesworthstone/franken_agent_detection",
         expected_rev: "7e288f493631020a4660443c5ad8fc7d4e49faa7",
         expected_version: "0.1.3",
-        expected_features: &["chatgpt", "connectors", "crush", "cursor", "opencode"],
+        expected_features: &["chatgpt", "connectors", "crush", "cursor", "hermes", "opencode"],
         expected_default_features: None,
         repo_rel: "../franken_agent_detection",
         manifest_rel: "Cargo.toml",

--- a/src/connectors/hermes.rs
+++ b/src/connectors/hermes.rs
@@ -1,0 +1,5 @@
+//! Connector for Hermes Agent session storage.
+//!
+//! Implementation lives in `franken_agent_detection::connectors::hermes`.
+
+pub use franken_agent_detection::HermesConnector;

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -211,6 +211,7 @@ pub mod crush;
 pub mod cursor;
 pub mod factory;
 pub mod gemini;
+pub mod hermes;
 pub mod kimi;
 pub mod openclaw;
 pub mod opencode;


### PR DESCRIPTION
## Summary

Hermes Agent's connector was added to `franken_agent_detection` in [PR #5](https://github.com/Dicklesworthstone/franken_agent_detection/pull/5) (feature-gated as `hermes`), but CASS never enabled the feature. As a result `cass capabilities --json | jq .connectors` lists 19 agents but no `hermes`, even though the connector code, tests, and a working SQLite reader for `~/.hermes/state.db` already exist upstream.

This PR wires it up:

- Enable the `hermes` feature on `franken-agent-detection`
- Update `expected_features` in build.rs path-dep contract
- Add the conventional re-export stub at `src/connectors/hermes.rs` (matches `gemini.rs`, `opencode.rs` pattern)
- Register the module in `src/connectors/mod.rs`

## Diff

```toml
-franken-agent-detection = { ..., features = ["connectors", "cursor", "chatgpt", "opencode", "crush"] }
+franken-agent-detection = { ..., features = ["connectors", "cursor", "chatgpt", "opencode", "crush", "hermes"] }
```

```rust
// src/connectors/hermes.rs (new)
//! Connector for Hermes Agent session storage.
//!
//! Implementation lives in `franken_agent_detection::connectors::hermes`.
pub use franken_agent_detection::HermesConnector;
```

## ⚠️ Prerequisite

This PR depends on a prerequisite re-export fix in `franken_agent_detection`: https://github.com/Dicklesworthstone/franken_agent_detection/pull/7

The currently-pinned rev `7e288f4` ships the connector implementation but does not re-export `HermesConnector` at the FAD crate root. This PR cannot compile against the existing rev — the FAD PR needs to merge first, then the rev pin in CASS needs to be bumped (I'm happy to follow up with that bump in this PR or a separate one, your preference).

## Verification (against a live install)

- Hermes session DB on hand: 763 sessions, 5644 messages in `~/.hermes/state.db`
- Schema matches connector expectations exactly (id/source/model/title/parent_session_id/started_at/ended_at/end_reason/message_count/tool_call_count/input_tokens/output_tokens on `sessions`; session_id/role/content/tool_calls/tool_name/tool_call_id/reasoning/timestamp on `messages`)
- No code path in this PR reaches Hermes-specific logic — it's purely registration plumbing

## Context

Use case: Jordan Strauss (silverdusk Oracle ARM box) runs Hermes Agent as the always-on assistant and OpenCode/Claude Code/Codex for coding. Cross-agent recall between them is the whole point of CASS for him, but Hermes sessions are currently invisible to `cass search`. With these two PRs landed, Hermes joins the existing 19 connectors.