### PR TITLE
Fix UBS changed-file gate install and baseline

### DIFF
--- a/.github/scripts/install-ubs.sh
+++ b/.github/scripts/install-ubs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version_file="${UBS_VERSION_FILE:-.github/workflows/ubs-version.txt}"
+install_dir="${UBS_INSTALL_DIR:-$HOME/.local/bin}"
+
+if [ -f "$version_file" ]; then
+  ubs_version="$(tr -d '[:space:]' < "$version_file")"
+else
+  ubs_version="latest"
+fi
+
+if [ -z "$ubs_version" ] || [ "$ubs_version" = "latest" ]; then
+  installer_ref="main"
+else
+  installer_ref="v$ubs_version"
+fi
+
+installer_url="https://raw.githubusercontent.com/Dicklesworthstone/ultimate_bug_scanner/${installer_ref}/install.sh"
+installer_path="${RUNNER_TEMP:-/tmp}/ubs-install-${installer_ref}.sh"
+
+echo "Installing Ultimate Bug Scanner from ${installer_url}"
+curl -fsSL "$installer_url" -o "$installer_path"
+bash "$installer_path" \
+  --non-interactive \
+  --skip-hooks \
+  --skip-version-check \
+  --install-dir "$install_dir"
+
+if [ -n "${GITHUB_PATH:-}" ]; then
+  echo "$install_dir" >> "$GITHUB_PATH"
+fi
+
+export PATH="$install_dir:$PATH"
+ubs --version
+ubs doctor

--- a/.github/scripts/run-ubs-changed-files.sh
+++ b/.github/scripts/run-ubs-changed-files.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p test-results
+
+range="${UBS_DIFF_RANGE:-}"
+if [ -z "$range" ]; then
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+    range="origin/${GITHUB_BASE_REF}...HEAD"
+  elif [ "${GITHUB_EVENT_NAME:-}" = "push" ] &&
+       [ "${GITHUB_REF:-}" = "refs/heads/main" ] &&
+       [ -n "${GITHUB_EVENT_BEFORE:-}" ]; then
+    range="${GITHUB_EVENT_BEFORE}...HEAD"
+  else
+    range="origin/main...HEAD"
+  fi
+fi
+
+base_ref="${UBS_BASE_REF:-}"
+if [ -z "$base_ref" ] && [[ "$range" == *"..."* ]]; then
+  base_ref="${range%%...*}"
+fi
+if [ -z "$base_ref" ]; then
+  base_ref="$(git merge-base origin/main HEAD)"
+fi
+
+echo "UBS diff range: $range"
+echo "UBS baseline ref: $base_ref"
+
+mapfile -d '' -t files < <(
+  git diff --name-only -z "$range" -- \
+    '*.rs' '*.toml' '*.ts' '*.tsx' '*.js' '*.jsx' '*.py' '*.sh' '*.yml' '*.yaml' '*.md' |
+    grep -z -v -E '^test-results/|^target/|^node_modules/' || true
+)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No UBS-relevant files changed; skipping gate."
+  exit 0
+fi
+
+printf 'UBS changed files (%s):\n' "${#files[@]}"
+printf '  %s\n' "${files[@]}" | head -40
+
+zero_json='{"project":"","timestamp":"","scanners":[],"totals":{"critical":0,"warning":0,"info":0,"files":0}}'
+
+scan_ubs_json() {
+  local output="$1"
+  local stderr_file="$2"
+  local scan_dir="$3"
+  shift 3
+
+  local output_abs stderr_abs
+  output_abs="$(realpath -m "$output")"
+  stderr_abs="$(realpath -m "$stderr_file")"
+
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "$zero_json" > "$output_abs"
+    : > "$stderr_abs"
+    return 0
+  fi
+
+  local rc=0
+  (
+    cd "$scan_dir"
+    ubs --format=json --ci "$@" > "$output_abs" 2> "$stderr_abs"
+  ) || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "UBS environment/tooling failure while scanning $output_abs" >&2
+    tail -80 "$stderr_abs" >&2 || true
+    return 2
+  fi
+
+  if ! jq -e '.totals' "$output_abs" >/dev/null 2>&1; then
+    if grep -q 'no recognizable languages' "$stderr_abs"; then
+      printf '%s\n' "$zero_json" > "$output_abs"
+      return 0
+    fi
+    echo "UBS did not produce a valid JSON report for $output_abs" >&2
+    tail -80 "$stderr_abs" >&2 || true
+    return 2
+  fi
+}
+
+baseline_dir="${RUNNER_TEMP:-/tmp}/ubs-baseline-${GITHUB_RUN_ID:-local}-$$"
+mkdir -p "$baseline_dir"
+baseline_files=()
+
+for file in "${files[@]}"; do
+  if git cat-file -e "${base_ref}:${file}" 2>/dev/null; then
+    mkdir -p "$baseline_dir/$(dirname "$file")"
+    git show "${base_ref}:${file}" > "$baseline_dir/$file"
+    baseline_files+=("$file")
+  fi
+done
+
+current_json="test-results/ubs-current.json"
+baseline_json="test-results/ubs-baseline.json"
+current_stderr="test-results/ubs-current.stderr.log"
+baseline_stderr="test-results/ubs-baseline.stderr.log"
+report_json="test-results/ubs-report.json"
+
+scan_ubs_json "$baseline_json" "$baseline_stderr" "$baseline_dir" "${baseline_files[@]}"
+scan_ubs_json "$current_json" "$current_stderr" "$PWD" "${files[@]}"
+
+jq -n \
+  --slurpfile current "$current_json" \
+  --slurpfile baseline "$baseline_json" \
+  --arg range "$range" \
+  --arg base_ref "$base_ref" \
+  --argjson files_count "${#files[@]}" \
+  '
+  def totals($doc):
+    ($doc[0].totals // {}) as $t |
+    {
+      critical: (($t.critical // 0) | tonumber),
+      warning: (($t.warning // 0) | tonumber),
+      info: (($t.info // 0) | tonumber),
+      files: (($t.files // 0) | tonumber)
+    };
+  totals($current) as $cur |
+  totals($baseline) as $base |
+  {
+    gate: "ubs-changed-files-baseline-delta",
+    range: $range,
+    baseline_ref: $base_ref,
+    changed_files: $files_count,
+    current: $current[0],
+    baseline: $baseline[0],
+    comparison: {
+      delta: {
+        critical: ($cur.critical - $base.critical),
+        warning: ($cur.warning - $base.warning),
+        info: ($cur.info - $base.info)
+      },
+      current_totals: $cur,
+      baseline_totals: $base
+    }
+  }' > "$report_json"
+
+critical_delta="$(jq -r '.comparison.delta.critical' "$report_json")"
+warning_delta="$(jq -r '.comparison.delta.warning' "$report_json")"
+
+echo "UBS current totals:  $(jq -c '.comparison.current_totals' "$report_json")"
+echo "UBS baseline totals: $(jq -c '.comparison.baseline_totals' "$report_json")"
+echo "UBS delta:           $(jq -c '.comparison.delta' "$report_json")"
+
+if [ "$critical_delta" -gt 0 ] || [ "$warning_delta" -gt 0 ]; then
+  echo "UBS FAIL: changed files introduce new critical or warning findings."
+  exit 1
+fi
+
+echo "UBS PASS: no new critical or warning findings versus the base-branch baseline."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,13 @@ jobs:
           ALLOWLIST_FILE="tests/policies/no_mock_allowlist.json"
           AUDIT_REPORT="test-results/no_mock_ci_audit.md"
 
-          echo "# No-Mock CI Audit" > "$AUDIT_REPORT"
-          echo "" >> "$AUDIT_REPORT"
-          echo "**Run:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$AUDIT_REPORT"
-          echo "**Commit:** ${{ github.sha }}" >> "$AUDIT_REPORT"
-          echo "" >> "$AUDIT_REPORT"
+          {
+            echo "# No-Mock CI Audit"
+            echo ""
+            echo "**Run:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "**Commit:** ${{ github.sha }}"
+            echo ""
+          } > "$AUDIT_REPORT"
 
           # Search for mock/fake/stub patterns
           VIOLATIONS=$(mktemp)
@@ -67,9 +69,11 @@ jobs:
           VIOLATION_COUNT=$(wc -l < "$VIOLATIONS" | tr -d ' ')
 
           if [ "$VIOLATION_COUNT" -eq 0 ]; then
-            echo "## Status: ✅ PASS" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "No mock/fake/stub patterns found." >> "$AUDIT_REPORT"
+            {
+              echo "## Status: ✅ PASS"
+              echo ""
+              echo "No mock/fake/stub patterns found."
+            } >> "$AUDIT_REPORT"
             echo "status=pass" >> "$GITHUB_OUTPUT"
             rm -f "$VIOLATIONS"
             exit 0
@@ -78,9 +82,11 @@ jobs:
           echo "Found $VIOLATION_COUNT pattern(s), checking allowlist..."
 
           if [ ! -f "$ALLOWLIST_FILE" ]; then
-            echo "## Status: ❌ FAIL" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "Allowlist file not found: $ALLOWLIST_FILE" >> "$AUDIT_REPORT"
+            {
+              echo "## Status: ❌ FAIL"
+              echo ""
+              echo "Allowlist file not found: $ALLOWLIST_FILE"
+            } >> "$AUDIT_REPORT"
             echo "status=fail" >> "$GITHUB_OUTPUT"
             rm -f "$VIOLATIONS"
             exit 1
@@ -114,33 +120,37 @@ jobs:
           rm -f "$VIOLATIONS"
 
           if [ "$UNALLOWED_COUNT" -gt 0 ]; then
-            echo "## Status: ❌ FAIL" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "**Unapproved patterns:** $UNALLOWED_COUNT" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "### Violations" >> "$AUDIT_REPORT"
-            echo -e "$UNALLOWED_LIST" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "### How to Fix" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "1. Replace mock/fake/stub with real fixtures (preferred)" >> "$AUDIT_REPORT"
-            echo "2. OR add to \`tests/policies/no_mock_allowlist.json\` with:" >> "$AUDIT_REPORT"
-            echo "   - \`rationale\`: Why this exception is necessary" >> "$AUDIT_REPORT"
-            echo "   - \`review_date\`: 6-month review date" >> "$AUDIT_REPORT"
-            echo "   - \`permanent: true\` only for true platform boundaries" >> "$AUDIT_REPORT"
-            echo "" >> "$AUDIT_REPORT"
-            echo "See TESTING.md 'No-Mock Policy' for details." >> "$AUDIT_REPORT"
+            {
+              echo "## Status: ❌ FAIL"
+              echo ""
+              echo "**Unapproved patterns:** $UNALLOWED_COUNT"
+              echo ""
+              echo "### Violations"
+              echo -e "$UNALLOWED_LIST"
+              echo ""
+              echo "### How to Fix"
+              echo ""
+              echo "1. Replace mock/fake/stub with real fixtures (preferred)"
+              echo "2. OR add to \`tests/policies/no_mock_allowlist.json\` with:"
+              echo "   - \`rationale\`: Why this exception is necessary"
+              echo "   - \`review_date\`: 6-month review date"
+              echo "   - \`permanent: true\` only for true platform boundaries"
+              echo ""
+              echo "See TESTING.md 'No-Mock Policy' for details."
+            } >> "$AUDIT_REPORT"
             echo "status=fail" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
-          echo "## Status: ✅ PASS" >> "$AUDIT_REPORT"
-          echo "" >> "$AUDIT_REPORT"
-          echo "**Total patterns found:** $VIOLATION_COUNT" >> "$AUDIT_REPORT"
-          echo "**All patterns allowlisted:** Yes" >> "$AUDIT_REPORT"
-          echo "" >> "$AUDIT_REPORT"
-          echo "### Allowlist Summary" >> "$AUDIT_REPORT"
-          echo "" >> "$AUDIT_REPORT"
+          {
+            echo "## Status: ✅ PASS"
+            echo ""
+            echo "**Total patterns found:** $VIOLATION_COUNT"
+            echo "**All patterns allowlisted:** Yes"
+            echo ""
+            echo "### Allowlist Summary"
+            echo ""
+          } >> "$AUDIT_REPORT"
           jq -r '.entries[] | "- `\(.path)`: \(.pattern)` — \(.rationale)"' "$ALLOWLIST_FILE" >> "$AUDIT_REPORT"
           echo "status=pass" >> "$GITHUB_OUTPUT"
 
@@ -188,8 +198,8 @@ jobs:
         run: cargo clippy --all-targets --features "qr encryption backtrace" -- -D warnings
 
   # UBS pre-merge gate per coding_agent_session_search-dpfvr.
-  # Runs `ubs --ci --fail-on-warning <changed-files>` against the diff for the
-  # PR (or push range on main). Skips when no relevant files changed.
+  # Runs UBS against changed files and fails when a PR introduces new critical
+  # or warning findings versus the same files from the base branch.
   ubs-changed-files:
     name: UBS (Ultimate Bug Scanner) Pre-Merge Gate
     needs: [no-mock-audit]
@@ -202,99 +212,25 @@ jobs:
           # `origin/main` must be reachable for `git diff origin/main...HEAD`.
           fetch-depth: 0
 
-      - name: Compute changed files
-        id: changed
-        shell: bash
-        run: |
-          set -euo pipefail
-          # PR runs: diff against the merge-base with the target branch.
-          # Push runs: diff against main's previous tip.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            range="origin/${{ github.base_ref }}...HEAD"
-          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            range="${{ github.event.before }}...HEAD"
-          else
-            # workflow_dispatch / other — diff against origin/main.
-            range="origin/main...HEAD"
-          fi
-          echo "Diff range: $range"
-
-          # Filter to the file extensions UBS supports. Skip everything else.
-          # Use a robust extension list and -z to handle filenames with spaces.
-          mapfile -t files < <(git diff --name-only "$range" -- \
-              '*.rs' '*.toml' '*.ts' '*.tsx' '*.js' '*.jsx' '*.py' '*.sh' '*.yml' '*.yaml' '*.md' \
-              2>/dev/null | grep -v -E '^test-results/|^target/|^node_modules/' || true)
-
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No UBS-relevant files changed; skipping gate."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          # Persist file list for the next step. Use NUL-delim safe via base64
-          # to avoid shell escaping issues with unusual filenames.
-          printf '%s\n' "${files[@]}" > /tmp/ubs-changed-files.txt
-          echo "files_count=${#files[@]}" >> "$GITHUB_OUTPUT"
-          echo "Files (first 20):"
-          head -20 /tmp/ubs-changed-files.txt
-
       - name: Install UBS
-        if: steps.changed.outputs.skip != 'true'
         shell: bash
-        run: |
-          set -euo pipefail
-          # UBS is distributed as a single shell installer per the project's
-          # README. We pin a version via .github/workflows/ubs-version.txt so
-          # CI is reproducible across runs. If the file is absent, fall back
-          # to the latest stable release tag.
-          if [ -f .github/workflows/ubs-version.txt ]; then
-            UBS_VERSION="$(tr -d '[:space:]' < .github/workflows/ubs-version.txt)"
-          else
-            UBS_VERSION="latest"
-          fi
-          echo "Installing UBS version: $UBS_VERSION"
-          # Heuristic install: prefer cargo-binstall -> direct binary -> source.
-          # The project's existing tooling assumes ubs is on PATH.
-          if command -v ubs >/dev/null 2>&1; then
-            echo "ubs already on PATH: $(command -v ubs)"
-            ubs --version || true
-          else
-            # Fall back: build from source. Slow but reliable.
-            cargo install ubs --locked --version "$UBS_VERSION" 2>/dev/null || \
-              cargo install ubs --locked
-          fi
+        run: .github/scripts/install-ubs.sh
 
-      - name: Run UBS on changed files
-        if: steps.changed.outputs.skip != 'true'
+      - name: Run UBS changed-file delta gate
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p test-results
-          # Pass the changed-file list to UBS. Use --ci for machine-readable
-          # output and --fail-on-warning so warnings block merge.
-          xargs -a /tmp/ubs-changed-files.txt \
-            ubs --ci --fail-on-warning \
-            > test-results/ubs-report.json 2> test-results/ubs-stderr.log || {
-              rc=$?
-              echo "UBS exited $rc"
-              echo "::group::UBS stderr (last 50 lines)"
-              tail -50 test-results/ubs-stderr.log || true
-              echo "::endgroup::"
-              echo "::group::UBS findings (jq)"
-              jq -c '.' test-results/ubs-report.json 2>/dev/null | head -100 || cat test-results/ubs-report.json | head -2000
-              echo "::endgroup::"
-              exit "$rc"
-            }
-          echo "UBS PASS — no findings on changed files."
+        run: .github/scripts/run-ubs-changed-files.sh
 
       - name: Upload UBS report
-        if: always() && steps.changed.outputs.skip != 'true'
+        if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           name: ubs-report-${{ github.run_id }}
           path: |
             test-results/ubs-report.json
-            test-results/ubs-stderr.log
+            test-results/ubs-current.json
+            test-results/ubs-baseline.json
+            test-results/ubs-current.stderr.log
+            test-results/ubs-baseline.stderr.log
           if-no-files-found: ignore
           retention-days: 7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,12 +218,13 @@ If you see errors, **carefully understand and resolve each issue**. Read suffici
 
 ### UBS Pre-Merge Gate
 
-Per `coding_agent_session_search-dpfvr`, every PR runs `ubs --ci --fail-on-warning` against the changed files in CI (`.github/workflows/ci.yml::ubs-changed-files`). The gate is **blocking** — warnings stop merges.
+Per `coding_agent_session_search-dpfvr`, every PR runs UBS against the changed files in CI (`.github/workflows/ci.yml::ubs-changed-files`). The gate is **blocking**: new critical or warning findings versus the same files on the base branch stop merges. Existing broad-file findings remain visible in the artifact, but do not block an unrelated patch unless the patch increases the critical or warning totals.
 
 **Local pre-flight before pushing:**
 
 ```bash
-ubs $(git diff --name-only origin/main...HEAD)
+.github/scripts/install-ubs.sh
+.github/scripts/run-ubs-changed-files.sh
 ```
 
 Or, scoped to staged files:
@@ -232,7 +233,7 @@ Or, scoped to staged files:
 ubs $(git diff --name-only --cached)
 ```
 
-If a known-acceptable warning needs to ship despite the gate, suppress at the UBS config level (`tests/policies/no_mock_allowlist.json` or per-file inline pragma) — never bypass by removing the gate.
+If a known-acceptable new warning needs to ship despite the gate, suppress at the UBS config level (`tests/policies/no_mock_allowlist.json` or per-file inline pragma) — never bypass by removing the gate.
 
 The pinned UBS version lives in `.github/workflows/ubs-version.txt`; the CI installer reads that file. Local installs should match.
 


### PR DESCRIPTION
## Summary
- install Ultimate Bug Scanner through its official installer instead of `cargo install ubs`
- replace broad changed-file blocking with a base-branch delta gate so existing file-wide UBS debt remains visible without blocking unrelated patches
- add reusable CI scripts and update AGENTS.md local preflight guidance
- clean an existing actionlint shell style issue in `ci.yml` so the workflow validates cleanly

## Verification
- `bash -n .github/scripts/install-ubs.sh .github/scripts/run-ubs-changed-files.sh`
- `shellcheck .github/scripts/install-ubs.sh .github/scripts/run-ubs-changed-files.sh`
- `.github/scripts/install-ubs.sh`
- `.github/scripts/run-ubs-changed-files.sh`
- `timeout 300 ubs $(git diff --name-only origin/main...HEAD) --fail-on-warning`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow YAML parsed"'`
- `actionlint .github/workflows/ci.yml`
- `rch exec -- env CARGO_TARGET_DIR=/tmp/cass-check-target cargo fmt --check`
