### PR TITLE
fix: stabilize CASS analytics rebuilds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ shell-words = "*"
 dotenvy = "*"
 notify = "*"
 frankensqlite = { version = "*", git = "https://github.com/Dicklesworthstone/frankensqlite", rev = "266dc98f", package = "fsqlite", features = ["fts5"] }
+# rusqlite is used for C-SQLite interop fixtures and the bounded
+# analytics-rebuild repair path; ordinary storage uses frankensqlite.
+rusqlite = { version = "*", features = ["bundled", "modern_sqlite"] }
 rayon = "*"
 crossbeam-channel = "*"
 parking_lot = "*"
@@ -142,9 +145,6 @@ arbitrary = { version = "1", features = ["derive"] }
 serde_yaml = "*"
 rand = "0.10"
 rand_chacha = "0.10"
-# rusqlite is retained only for C-SQLite interop fixtures in tests; production
-# storage and historical salvage paths use frankensqlite.
-rusqlite = { version = "*", features = ["bundled", "modern_sqlite"] }
 # frankensqlite compat gate tests (bead 3vvqa) — fsqlite-types needed for SqliteValue
 # enum variants in test assertions. The main fsqlite dep is available as `frankensqlite`.
 fsqlite-types = { version = "*", git = "https://github.com/Dicklesworthstone/frankensqlite", rev = "266dc98f", package = "fsqlite-types" }

--- a/src/analytics/validate.rs
+++ b/src/analytics/validate.rs
@@ -584,9 +584,7 @@ fn validate_track_b(conn: &Connection, config: &ValidateConfig) -> (Vec<Check>, 
             ok: false,
             severity: Severity::Error,
             details: "Track B tables missing (token_daily_stats or token_usage)".into(),
-            suggested_action: Some(
-                "Run 'cass analytics rebuild --track all' (requires z9fse.13)".into(),
-            ),
+            suggested_action: Some("Run 'cass analytics rebuild --track all'".into()),
         });
         return (checks, 0, 0);
     }
@@ -617,29 +615,69 @@ fn validate_track_b(conn: &Connection, config: &ValidateConfig) -> (Vec<Check>, 
 
     let sql = if has_agents_table {
         format!(
-            "SELECT tds.day_id, tds.agent_slug, tds.source_id, tds.model_family,
-                    tds.grand_total_tokens,
-                    COALESCE(tu.sum_total, 0),
-                    tds.total_tool_calls,
-                    COALESCE(tu.sum_tools, 0),
-                    tds.api_call_count,
-                    COALESCE(tu.sum_rows, 0)
-             FROM token_daily_stats tds
-             LEFT JOIN (
+            "WITH raw AS (
                  SELECT t.day_id,
-                        a.slug AS agent_slug,
-                        t.source_id,
+                        COALESCE(a.slug, 'unknown') AS agent_slug,
+                        COALESCE(c.source_id, 'local') AS source_id,
                         COALESCE(t.model_family, 'unknown') AS model_family,
-                        SUM(COALESCE(t.total_tokens, 0)) AS sum_total,
+                        SUM(COALESCE(
+                            t.total_tokens,
+                            COALESCE(t.input_tokens, 0) +
+                            COALESCE(t.output_tokens, 0) +
+                            COALESCE(t.cache_read_tokens, 0) +
+                            COALESCE(t.cache_creation_tokens, 0) +
+                            COALESCE(t.thinking_tokens, 0)
+                        )) AS sum_total,
                         SUM(t.tool_call_count) AS sum_tools,
                         COUNT(*) AS sum_rows
                  FROM token_usage t
-                 JOIN agents a ON a.id = t.agent_id
-                 GROUP BY t.day_id, a.slug, t.source_id, COALESCE(t.model_family, 'unknown')
-             ) tu ON tds.day_id = tu.day_id
-                   AND tds.agent_slug = tu.agent_slug
-                   AND tds.source_id = tu.source_id
-                   AND tds.model_family = tu.model_family
+                 LEFT JOIN conversations c ON c.id = t.conversation_id
+                 LEFT JOIN agents a ON a.id = c.agent_id
+                 GROUP BY
+                    t.day_id,
+                    COALESCE(a.slug, 'unknown'),
+                    COALESCE(c.source_id, 'local'),
+                    COALESCE(t.model_family, 'unknown')
+             ),
+             expanded AS (
+                 SELECT * FROM raw
+                 UNION ALL
+                 SELECT day_id, 'all', source_id, model_family, sum_total, sum_tools, sum_rows
+                 FROM raw
+                 WHERE agent_slug != 'all'
+                 UNION ALL
+                 SELECT day_id, agent_slug, 'all', model_family, sum_total, sum_tools, sum_rows
+                 FROM raw
+                 WHERE source_id != 'all'
+                 UNION ALL
+                 SELECT day_id, agent_slug, source_id, 'all', sum_total, sum_tools, sum_rows
+                 FROM raw
+                 WHERE model_family != 'all'
+                 UNION ALL
+                 SELECT day_id, 'all', 'all', 'all', sum_total, sum_tools, sum_rows
+                 FROM raw
+                 WHERE NOT (agent_slug = 'all' AND source_id = 'all' AND model_family = 'all')
+             ),
+             expected AS (
+                 SELECT day_id, agent_slug, source_id, model_family,
+                        SUM(sum_total) AS sum_total,
+                        SUM(sum_tools) AS sum_tools,
+                        SUM(sum_rows) AS sum_rows
+                 FROM expanded
+                 GROUP BY day_id, agent_slug, source_id, model_family
+             )
+             SELECT tds.day_id, tds.agent_slug, tds.source_id, tds.model_family,
+                    tds.grand_total_tokens,
+                    COALESCE(expected.sum_total, 0),
+                    tds.total_tool_calls,
+                    COALESCE(expected.sum_tools, 0),
+                    tds.api_call_count,
+                    COALESCE(expected.sum_rows, 0)
+             FROM token_daily_stats tds
+             LEFT JOIN expected ON tds.day_id = expected.day_id
+                   AND tds.agent_slug = expected.agent_slug
+                   AND tds.source_id = expected.source_id
+                   AND tds.model_family = expected.model_family
              ORDER BY tds.day_id DESC
              {limit_clause}"
         )
@@ -819,9 +857,26 @@ fn validate_cross_track_drift(
     }
 
     let track_b_rows = match conn.query_map_collect(
-        "SELECT day_id, agent_slug, source_id, SUM(grand_total_tokens) AS grand_total
-         FROM token_daily_stats
-         GROUP BY day_id, agent_slug, source_id",
+        "SELECT
+             t.day_id,
+             COALESCE(a.slug, 'unknown') AS agent_slug,
+             COALESCE(c.source_id, t.source_id, 'local') AS source_id,
+             SUM(COALESCE(
+                 t.total_tokens,
+                 COALESCE(t.input_tokens, 0) +
+                 COALESCE(t.output_tokens, 0) +
+                 COALESCE(t.cache_read_tokens, 0) +
+                 COALESCE(t.cache_creation_tokens, 0) +
+                 COALESCE(t.thinking_tokens, 0)
+             )) AS api_total
+         FROM token_usage t
+         LEFT JOIN conversations c ON c.id = t.conversation_id
+         LEFT JOIN agents a ON a.id = COALESCE(c.agent_id, t.agent_id)
+         WHERE t.data_source = 'api'
+         GROUP BY
+             t.day_id,
+             COALESCE(a.slug, 'unknown'),
+             COALESCE(c.source_id, t.source_id, 'local')",
         &[],
         |row: &Row| {
             Ok((
@@ -1270,6 +1325,14 @@ mod tests {
             );
             INSERT INTO agents VALUES (1, 'claude_code');
 
+            CREATE TABLE conversations (
+                id INTEGER PRIMARY KEY,
+                agent_id INTEGER NOT NULL,
+                source_id TEXT NOT NULL DEFAULT 'local',
+                started_at INTEGER
+            );
+            INSERT INTO conversations VALUES (100, 1, 'local', 1750000000000);
+
             CREATE TABLE token_usage (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 message_id INTEGER NOT NULL,
@@ -1437,6 +1500,56 @@ mod tests {
         assert!(!report.drift.is_empty());
         assert_eq!(report.drift[0].track_a_total, 880);
         assert_eq!(report.drift[0].track_b_total, 0);
+    }
+
+    #[test]
+    fn cross_track_drift_ignores_estimated_only_track_b_rows() {
+        let conn = setup_both_tracks_fixture();
+
+        conn.execute("INSERT INTO conversations VALUES (101, 1, 'local', 1750086400000)")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO token_usage (
+                id, message_id, conversation_id, agent_id, workspace_id, source_id,
+                timestamp_ms, day_id, model_name, model_family, model_tier, service_tier,
+                provider, input_tokens, output_tokens, cache_read_tokens,
+                cache_creation_tokens, thinking_tokens, total_tokens, estimated_cost_usd,
+                role, content_chars, has_tool_calls, tool_call_count, data_source
+             ) VALUES (
+                2, 3, 101, 1, 1, 'local',
+                1750086400000, 20255, NULL, 'unknown', NULL, NULL,
+                NULL, 0, 123, NULL,
+                NULL, NULL, 123, NULL,
+                'assistant', 492, 0, 0, 'estimated'
+             )",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO token_daily_stats (
+                day_id, agent_slug, source_id, model_family,
+                api_call_count, assistant_message_count,
+                total_output_tokens, grand_total_tokens, total_content_chars,
+                total_tool_calls, session_count, last_updated
+             ) VALUES (
+                20255, 'claude_code', 'local', 'unknown',
+                1, 1,
+                123, 123, 492,
+                0, 1, 0
+             )",
+        )
+        .unwrap();
+
+        let (checks, drift) = validate_cross_track_drift(&conn, &ValidateConfig::deep());
+        let drift_check = checks
+            .iter()
+            .find(|check| check.id == "cross_track.drift")
+            .expect("cross-track drift check");
+
+        assert!(
+            drift_check.ok,
+            "estimated-only token rows must not be compared to Track A API totals: {drift:#?}"
+        );
+        assert!(drift.is_empty());
     }
 
     #[test]

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -65,7 +65,8 @@ use crate::sources::provenance::{LOCAL_SOURCE_ID, Origin, Source, SourceKind};
 use crate::sources::sync::path_to_safe_dirname;
 use crate::storage::sqlite::{
     DailyStatsRebuildResult, FrankenStorage, FtsConsistencyRepair, HistoricalSalvageOutcome,
-    MigrationError, StatsAggregator, StatsDelta, seed_canonical_from_best_historical_bundle,
+    InsertConversationsOptions, MigrationError, StatsAggregator, StatsDelta,
+    seed_canonical_from_best_historical_bundle,
 };
 use semantic::{
     EmbeddingInput, SemanticIndexer, packet_embedding_inputs_from_storage,
@@ -534,6 +535,133 @@ impl CanonicalMutationCounts {
     fn changed(self) -> bool {
         self.inserted_conversations > 0 || self.inserted_messages > 0
     }
+}
+
+fn should_commit_streaming_final_tantivy(total_conversations: usize) -> bool {
+    total_conversations > 0
+}
+
+fn should_commit_tantivy_after_scan(
+    scan_requires_tantivy: bool,
+    scan_canonical_mutations: CanonicalMutationCounts,
+) -> bool {
+    scan_requires_tantivy && scan_canonical_mutations.changed()
+}
+
+fn should_skip_watch_startup_broad_incremental_scan(
+    watch: bool,
+    full: bool,
+    force_rebuild: bool,
+    needs_rebuild: bool,
+    salvage_messages_imported: usize,
+) -> bool {
+    watch && !full && !force_rebuild && !needs_rebuild && salvage_messages_imported == 0
+}
+
+fn should_ignore_watch_startup_notification(now: Instant, ignore_until: Instant) -> bool {
+    now < ignore_until
+}
+
+fn watch_incremental_since_ts(previous_ts: Option<i64>, min_ts: Option<i64>) -> Option<i64> {
+    match previous_ts {
+        Some(ts) => Some(ts.saturating_sub(1)),
+        None => min_ts.map(|ts| ts.saturating_sub(1)),
+    }
+}
+
+fn should_skip_steady_watch_trigger(previous_ts: Option<i64>, max_ts: Option<i64>) -> bool {
+    matches!((previous_ts, max_ts), (Some(previous), Some(batch_max)) if batch_max < previous)
+}
+
+fn watch_inline_tantivy_enabled() -> bool {
+    env_flag_enabled("CASS_WATCH_INLINE_TANTIVY", false)
+}
+
+fn watch_opencode_enabled() -> bool {
+    env_flag_enabled("CASS_WATCH_OPENCODE", false)
+}
+
+fn index_defer_storage_derived_updates_enabled() -> bool {
+    env_flag_enabled("CASS_INDEX_DEFER_DERIVED_UPDATES", false)
+}
+
+fn index_defer_tantivy_updates_enabled() -> bool {
+    env_flag_enabled("CASS_INDEX_DEFER_TANTIVY_UPDATES", false)
+}
+
+fn should_defer_incremental_tantivy_updates_to_authoritative_rebuild(
+    opts: &IndexOptions,
+    needs_rebuild: bool,
+    salvage_messages_imported: usize,
+) -> bool {
+    !opts.watch
+        && !opts.full
+        && !opts.force_rebuild
+        && !needs_rebuild
+        && salvage_messages_imported == 0
+        && index_defer_tantivy_updates_enabled()
+}
+
+fn insert_options_for_source_scan(
+    opts: &IndexOptions,
+    lexical_strategy: LexicalPopulationStrategy,
+) -> InsertConversationsOptions {
+    if !opts.watch
+        && !opts.full
+        && !matches!(
+            lexical_strategy,
+            LexicalPopulationStrategy::InlineRebuildFromScan
+        )
+        && index_defer_storage_derived_updates_enabled()
+    {
+        InsertConversationsOptions::defer_derived_updates()
+    } else {
+        InsertConversationsOptions::from_env()
+    }
+}
+
+fn resolve_source_scan_lexical_population_strategy(
+    opts: &IndexOptions,
+    needs_rebuild: bool,
+    salvage_messages_imported: usize,
+) -> (LexicalPopulationStrategy, &'static str) {
+    if should_defer_incremental_tantivy_updates_to_authoritative_rebuild(
+        opts,
+        needs_rebuild,
+        salvage_messages_imported,
+    ) {
+        return (
+            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+            "incremental_scan_defers_inline_tantivy_updates_to_authoritative_db_rebuild",
+        );
+    }
+
+    resolve_lexical_population_strategy(needs_rebuild, opts.full, salvage_messages_imported)
+}
+
+fn should_run_post_scan_authoritative_rebuild(
+    full_refresh: bool,
+    lexical_strategy: LexicalPopulationStrategy,
+    salvage_messages_imported: usize,
+) -> bool {
+    full_refresh
+        || salvage_messages_imported > 0
+        || matches!(
+            lexical_strategy,
+            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild
+        )
+}
+
+fn env_flag_enabled(key: &str, default: bool) -> bool {
+    dotenvy::var(key)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(default)
 }
 
 #[derive(Debug, Default)]
@@ -6472,7 +6600,7 @@ fn choose_incremental_canonical_lexical_repair_plan(
     }
 
     let observed_tantivy_docs = context.observed_tantivy_docs?;
-    if observed_tantivy_docs < context.canonical_messages {
+    if observed_tantivy_docs == 0 {
         return Some(IncrementalCanonicalLexicalRepairPlan {
             canonical_messages: context.canonical_messages,
             observed_tantivy_docs: Some(observed_tantivy_docs),
@@ -6603,7 +6731,7 @@ fn should_skip_unchanged_explicit_watch_once_paths(
         return Ok(false);
     };
 
-    let triggers = classify_paths(paths.clone(), roots, true);
+    let triggers = classify_paths(paths.clone(), roots, true, false);
     if triggers.is_empty() {
         return Ok(true);
     }
@@ -8578,6 +8706,15 @@ fn spawn_connector_producer(
         // Scan explicitly configured additional roots. These may be true remote
         // mirrors or machine-local backup directories wired through sources.toml.
         for root in &config.additional_scan_roots {
+            if !additional_scan_root_matches_connector(name, root) {
+                tracing::debug!(
+                    connector = name,
+                    root = %root.path.display(),
+                    source_id = %root.origin.source_id,
+                    "skipping additional scan root with provider-specific local hint"
+                );
+                continue;
+            }
             let ctx = crate::connectors::ScanContext::with_roots(
                 root.path.clone(),
                 vec![root.clone()],
@@ -8682,6 +8819,61 @@ fn spawn_connector_producer(
     })
 }
 
+fn additional_scan_root_matches_connector(connector_name: &str, root: &ScanRoot) -> bool {
+    let Some(kind) = ConnectorKind::from_slug(connector_name) else {
+        return true;
+    };
+    additional_scan_root_matches_kind(kind, root)
+}
+
+fn additional_scan_root_matches_kind(kind: ConnectorKind, root: &ScanRoot) -> bool {
+    if root.origin.is_remote() {
+        return true;
+    }
+    connector_hint_for_local_scan_root(root).is_none_or(|hint| hint == kind)
+}
+
+fn connector_hint_for_local_scan_root(root: &ScanRoot) -> Option<ConnectorKind> {
+    connector_hint_from_text(&root.origin.source_id)
+        .or_else(|| connector_hint_from_text(&root.path.to_string_lossy()))
+}
+
+fn connector_hint_from_text(text: &str) -> Option<ConnectorKind> {
+    let lower = text.to_ascii_lowercase();
+    for (needle, kind) in [
+        ("opencode", ConnectorKind::OpenCode),
+        ("openclaw", ConnectorKind::OpenClaw),
+        ("copilot-cli", ConnectorKind::CopilotCli),
+        ("copilot_cli", ConnectorKind::CopilotCli),
+        ("chatgpt", ConnectorKind::ChatGpt),
+        ("pi-agent", ConnectorKind::PiAgent),
+        ("pi_agent", ConnectorKind::PiAgent),
+        ("clawdbot", ConnectorKind::Clawdbot),
+        ("claude", ConnectorKind::Claude),
+        ("gemini", ConnectorKind::Gemini),
+        ("codex", ConnectorKind::Codex),
+        ("cursor", ConnectorKind::Cursor),
+        ("aider", ConnectorKind::Aider),
+        ("factory", ConnectorKind::Factory),
+        ("cline", ConnectorKind::Cline),
+        ("vibe", ConnectorKind::Vibe),
+        ("kimi", ConnectorKind::Kimi),
+        ("qwen", ConnectorKind::Qwen),
+    ] {
+        if lower.contains(needle) {
+            return Some(kind);
+        }
+    }
+
+    lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .find_map(|token| match token {
+            "amp" => Some(ConnectorKind::Amp),
+            _ => None,
+        })
+}
+
 /// Base commit cadence for the streaming indexing consumer. Default is 5s;
 /// can be overridden at process start via `CASS_STREAMING_CONSUMER_COMMIT_SECS`.
 /// Must return at least 1s to avoid pathological tight-loop commits even if
@@ -8770,6 +8962,7 @@ fn run_streaming_consumer(
     flow_limiter: Arc<StreamingByteLimiter>,
     progress: &Option<Arc<IndexingProgress>>,
     lexical_strategy: LexicalPopulationStrategy,
+    insert_options: InsertConversationsOptions,
     scan_start_ts: Option<i64>,
 ) -> Result<(Vec<String>, CanonicalMutationCounts)> {
     use std::collections::HashMap;
@@ -8934,8 +9127,11 @@ fn run_streaming_consumer(
                     data_dir,
                     &combined_conversations,
                     progress,
-                    lexical_strategy,
-                    defer_streaming_checkpoints,
+                    IngestBatchOptions {
+                        lexical_strategy,
+                        defer_checkpoints: defer_streaming_checkpoints,
+                        insert_options,
+                    },
                 );
                 flow_limiter.release(combined_byte_reservation);
                 canonical_mutations = canonical_mutations.accumulate(ingest_result?);
@@ -9049,9 +9245,16 @@ fn run_streaming_consumer(
         }
     }
 
-    // Final commit to ensure all data is persisted
-    if let Some(t_index) = t_index {
-        t_index.commit()?;
+    // Final commit to ensure all data is persisted. A zero-batch incremental
+    // scan did not touch the writer, so avoid waking Tantivy's commit path.
+    if should_commit_streaming_final_tantivy(total_conversations) {
+        if let Some(t_index) = t_index {
+            t_index.commit()?;
+        }
+    } else if t_index.is_some() {
+        tracing::info!(
+            "skipping streaming final Tantivy commit because scan produced no conversations"
+        );
     }
 
     let index_ms = index_start.elapsed().as_millis() as u64;
@@ -9096,24 +9299,26 @@ fn run_streaming_index(
     storage: &FrankenStorage,
     t_index: Option<&mut TantivyIndex>,
     opts: &IndexOptions,
-    since_ts: Option<i64>,
-    lexical_strategy: LexicalPopulationStrategy,
-    additional_scan_roots: Vec<ScanRoot>,
-    scan_start_ts: i64,
+    scan_options: ScanRunOptions,
 ) -> Result<CanonicalMutationCounts> {
     run_streaming_index_with_connector_factories(
         storage,
         t_index,
         opts,
-        since_ts,
-        lexical_strategy,
-        additional_scan_roots,
+        scan_options,
         configured_connector_factories(),
-        scan_start_ts,
     )
 }
 
 type ConnectorFactory = fn() -> Box<dyn Connector + Send>;
+
+struct ScanRunOptions {
+    since_ts: Option<i64>,
+    lexical_strategy: LexicalPopulationStrategy,
+    insert_options: InsertConversationsOptions,
+    additional_scan_roots: Vec<ScanRoot>,
+    scan_start_ts: i64,
+}
 
 fn configured_connector_factories() -> Vec<(&'static str, ConnectorFactory)> {
     filter_disabled_connector_factories(get_connector_factories())
@@ -9161,12 +9366,17 @@ fn run_streaming_index_with_connector_factories(
     storage: &FrankenStorage,
     t_index: Option<&mut TantivyIndex>,
     opts: &IndexOptions,
-    since_ts: Option<i64>,
-    lexical_strategy: LexicalPopulationStrategy,
-    additional_scan_roots: Vec<ScanRoot>,
+    scan_options: ScanRunOptions,
     connector_factories: Vec<(&'static str, ConnectorFactory)>,
-    scan_start_ts: i64,
 ) -> Result<CanonicalMutationCounts> {
+    let ScanRunOptions {
+        since_ts,
+        lexical_strategy,
+        insert_options,
+        additional_scan_roots,
+        scan_start_ts,
+    } = scan_options;
+
     if connector_factories.is_empty() {
         tracing::warn!("no enabled connectors are configured for indexing; skipping scan");
         if let Some(p) = &opts.progress {
@@ -9242,6 +9452,7 @@ fn run_streaming_index_with_connector_factories(
         producer_config.flow_limiter.clone(),
         &opts.progress,
         lexical_strategy,
+        insert_options,
         Some(scan_start_ts),
     );
 
@@ -9304,20 +9515,14 @@ fn run_batch_index(
     storage: &FrankenStorage,
     t_index: Option<&mut TantivyIndex>,
     opts: &IndexOptions,
-    since_ts: Option<i64>,
-    lexical_strategy: LexicalPopulationStrategy,
-    additional_scan_roots: Vec<ScanRoot>,
-    scan_start_ts: i64,
+    scan_options: ScanRunOptions,
 ) -> Result<CanonicalMutationCounts> {
     run_batch_index_with_connector_factories(
         storage,
         t_index,
         opts,
-        since_ts,
-        lexical_strategy,
-        additional_scan_roots,
+        scan_options,
         configured_connector_factories(),
-        scan_start_ts,
     )
 }
 
@@ -9326,12 +9531,17 @@ fn run_batch_index_with_connector_factories(
     storage: &FrankenStorage,
     mut t_index: Option<&mut TantivyIndex>,
     opts: &IndexOptions,
-    since_ts: Option<i64>,
-    lexical_strategy: LexicalPopulationStrategy,
-    additional_scan_roots: Vec<ScanRoot>,
+    scan_options: ScanRunOptions,
     connector_factories: Vec<(&'static str, ConnectorFactory)>,
-    scan_start_ts: i64,
 ) -> Result<CanonicalMutationCounts> {
+    let ScanRunOptions {
+        since_ts,
+        lexical_strategy,
+        insert_options,
+        additional_scan_roots,
+        scan_start_ts,
+    } = scan_options;
+
     let scan_start = std::time::Instant::now();
 
     // First pass: Scan all to get counts if we have progress tracker
@@ -9410,6 +9620,15 @@ fn run_batch_index_with_connector_factories(
 
                 if !additional_scan_roots.is_empty() {
                     for root in &additional_scan_roots {
+                        if !additional_scan_root_matches_connector(name, root) {
+                            tracing::debug!(
+                                connector = name,
+                                root = %root.path.display(),
+                                source_id = %root.origin.source_id,
+                                "skipping additional scan root with provider-specific local hint"
+                            );
+                            continue;
+                        }
                         let ctx = crate::connectors::ScanContext::with_roots(
                             root.path.clone(),
                             vec![root.clone()],
@@ -9523,8 +9742,11 @@ fn run_batch_index_with_connector_factories(
             &opts.data_dir,
             &convs,
             &opts.progress,
-            lexical_strategy,
-            !opts.watch,
+            IngestBatchOptions {
+                lexical_strategy,
+                defer_checkpoints: !opts.watch,
+                insert_options,
+            },
         )?);
         // Periodically persist scan_start_ts so that if the process is killed,
         // the next run does a delta scan instead of a full rescan (infinite-OOM-loop fix).
@@ -9993,7 +10215,7 @@ pub fn run_index(
     let mut exact_completed_lexical_checkpoint = false;
     let mut skipped_noop_full_scan_authoritative_rebuild = false;
     let mut targeted_watch_once_only_run = false;
-    let t_index = if resume_lexical_rebuild {
+    let mut t_index = if resume_lexical_rebuild {
         tracing::info!(
             db_path = %opts.db_path.display(),
             "resuming incomplete lexical rebuild from canonical database checkpoint"
@@ -10291,11 +10513,23 @@ pub fn run_index(
                     db_path = %opts.db_path.display(),
                     "skipping broad incremental scan because targeted watch-once paths were supplied after authoritative lexical repair"
                 );
+            } else if should_skip_watch_startup_broad_incremental_scan(
+                opts.watch,
+                opts.full,
+                opts.force_rebuild,
+                needs_rebuild,
+                historical_salvage.messages_imported,
+            ) {
+                tracing::info!(
+                    db_path = %opts.db_path.display(),
+                    followup_scan_after_authoritative_repair,
+                    "skipping broad incremental scan during watch startup; steady-state watcher will index filesystem events"
+                );
             } else {
                 let (lexical_strategy, lexical_strategy_reason) =
-                    resolve_lexical_population_strategy(
+                    resolve_source_scan_lexical_population_strategy(
+                        &opts,
                         needs_rebuild,
-                        opts.full,
                         historical_salvage.messages_imported,
                     );
                 record_lexical_population_strategy_if_unset(
@@ -10355,6 +10589,17 @@ pub fn run_index(
                         "scan phase is deferring Tantivy writer open/commit until the authoritative rebuild"
                     );
                 }
+                let scan_insert_options = insert_options_for_source_scan(&opts, lexical_strategy);
+                if scan_insert_options.defer_lexical_updates
+                    || scan_insert_options.defer_analytics_updates
+                {
+                    tracing::info!(
+                        strategy = lexical_strategy.as_str(),
+                        defer_storage_lexical_updates = scan_insert_options.defer_lexical_updates,
+                        defer_analytics_updates = scan_insert_options.defer_analytics_updates,
+                        "source scan is deferring storage-derived updates during canonical ingest"
+                    );
+                }
                 if streaming_index_enabled() {
                     tracing::info!("using streaming indexing (Opt 8.2)");
                     scan_canonical_mutations =
@@ -10362,10 +10607,13 @@ pub fn run_index(
                             &storage,
                             t_index.as_mut(),
                             &opts,
-                            since_ts,
-                            lexical_strategy,
-                            additional_scan_roots.clone(),
-                            scan_start_ts,
+                            ScanRunOptions {
+                                since_ts,
+                                lexical_strategy,
+                                insert_options: scan_insert_options,
+                                additional_scan_roots: additional_scan_roots.clone(),
+                                scan_start_ts,
+                            },
                         )?);
                 } else {
                     tracing::info!(
@@ -10376,22 +10624,34 @@ pub fn run_index(
                             &storage,
                             t_index.as_mut(),
                             &opts,
-                            since_ts,
-                            lexical_strategy,
-                            additional_scan_roots.clone(),
-                            scan_start_ts,
+                            ScanRunOptions {
+                                since_ts,
+                                lexical_strategy,
+                                insert_options: scan_insert_options,
+                                additional_scan_roots: additional_scan_roots.clone(),
+                                scan_start_ts,
+                            },
                         )?);
                 }
                 performed_scan = true;
 
-                if scan_requires_tantivy {
+                if should_commit_tantivy_after_scan(scan_requires_tantivy, scan_canonical_mutations)
+                {
                     t_index
                         .as_mut()
                         .expect("tantivy index must remain open for lexical commit")
                         .commit()?;
+                } else if scan_requires_tantivy {
+                    tracing::info!(
+                        "skipping post-scan Tantivy commit because scan made no canonical changes"
+                    );
                 }
 
-                if opts.full || historical_salvage.messages_imported > 0 {
+                if should_run_post_scan_authoritative_rebuild(
+                    opts.full,
+                    lexical_strategy,
+                    historical_salvage.messages_imported,
+                ) {
                     let post_scan_observed_tantivy_docs =
                         observed_tantivy_docs_for_post_full_scan_skip(
                             &index_path,
@@ -10721,7 +10981,18 @@ pub fn run_index(
     if opts.watch || opts.watch_once_paths.is_some() {
         let additional_scan_roots =
             additional_scan_roots_for_scan_or_watch(&storage, &opts.data_dir);
-        let watch_roots = build_watch_roots(additional_scan_roots.clone());
+        let mut watch_roots = build_watch_roots(additional_scan_roots.clone());
+        if opts.watch && !watch_opencode_enabled() {
+            let before = watch_roots.len();
+            watch_roots.retain(|(kind, _)| *kind != ConnectorKind::OpenCode);
+            let removed = before.saturating_sub(watch_roots.len());
+            if removed > 0 {
+                tracing::info!(
+                    removed,
+                    "skipping OpenCode roots in steady-state watch mode; set CASS_WATCH_OPENCODE=1 to opt in"
+                );
+            }
+        }
         let watch_once_mode = opts
             .watch_once_paths
             .as_ref()
@@ -10757,13 +11028,34 @@ pub fn run_index(
         restore_watch_steady_state_checkpoint_policy(&storage, opts.watch);
         if opts.watch {
             index_run_lock.set_mode(SearchMaintenanceMode::Watch)?;
+            if t_index.is_some() {
+                tracing::info!(
+                    "closing startup Tantivy writer before entering steady-state watch mode"
+                );
+                t_index = None;
+            }
         }
 
         let opts_clone = opts.clone();
-        let state = Mutex::new(load_watch_state(&opts.data_dir));
+        let mut initial_watch_state = load_watch_state(&opts.data_dir);
+        if opts.watch && !watch_once_mode {
+            let watch_state_seeded = seed_watch_state_for_steady_watch(
+                &opts.data_dir,
+                &mut initial_watch_state,
+                &watch_roots,
+                FrankenStorage::now_millis(),
+            )?;
+            if watch_state_seeded {
+                tracing::info!(
+                    watch_roots = watch_roots.len(),
+                    "seeded watch state high-water marks before entering steady-state watch mode"
+                );
+            }
+        }
+        let state = Mutex::new(initial_watch_state);
         let storage = Rc::new(Mutex::new(storage));
         let storage_for_watch = Rc::clone(&storage);
-        let should_preopen_tantivy_for_watch = opts.watch;
+        let should_preopen_tantivy_for_watch = false;
         let watch_once_defers_tantivy_open =
             watch_once_mode && !should_preopen_tantivy_for_watch && t_index.is_none();
         let t_index = Mutex::new(if should_preopen_tantivy_for_watch {
@@ -15444,17 +15736,27 @@ fn rebuild_tantivy_from_db_with_options(
     })
 }
 
+#[derive(Clone, Copy)]
+struct IngestBatchOptions {
+    lexical_strategy: LexicalPopulationStrategy,
+    defer_checkpoints: bool,
+    insert_options: InsertConversationsOptions,
+}
+
 fn ingest_batch(
     storage: &FrankenStorage,
     t_index: Option<&mut TantivyIndex>,
     data_dir: &Path,
     convs: &[NormalizedConversation],
     progress: &Option<Arc<IndexingProgress>>,
-    lexical_strategy: LexicalPopulationStrategy,
-    defer_checkpoints: bool,
+    options: IngestBatchOptions,
 ) -> Result<CanonicalMutationCounts> {
-    let trace_span =
-        robot_trace_ingest_start("ingest_batch", convs, lexical_strategy, defer_checkpoints);
+    let trace_span = robot_trace_ingest_start(
+        "ingest_batch",
+        convs,
+        options.lexical_strategy,
+        options.defer_checkpoints,
+    );
     // Persistence now uses short-lived writer connections internally so the
     // long-lived watch/session handle does not accumulate retained MVCC state
     // on older frankensqlite builds that ignore autocommit_retain.
@@ -15463,8 +15765,9 @@ fn ingest_batch(
         t_index,
         data_dir,
         convs,
-        lexical_strategy,
-        defer_checkpoints,
+        options.lexical_strategy,
+        options.defer_checkpoints,
+        options.insert_options,
     );
     let batch_outcome = match batch_result {
         Ok(batch_outcome) => batch_outcome,
@@ -15501,6 +15804,7 @@ fn ingest_batch_with_semantic_delta(
     lexical_strategy: LexicalPopulationStrategy,
     defer_checkpoints: bool,
     semantic_delta: Option<&mut WatchSemanticDelta>,
+    insert_options: InsertConversationsOptions,
 ) -> Result<persist::PersistBatchOutcome> {
     let trace_span = robot_trace_ingest_start(
         "ingest_batch_with_semantic_delta",
@@ -15516,6 +15820,7 @@ fn ingest_batch_with_semantic_delta(
             convs,
             lexical_strategy,
             defer_checkpoints,
+            insert_options,
         )
     } else {
         persist::persist_conversations_batched_with_raw_mirror_links(
@@ -15525,6 +15830,7 @@ fn ingest_batch_with_semantic_delta(
             convs,
             lexical_strategy,
             defer_checkpoints,
+            insert_options,
         )
     };
     let batch_outcome = match batch_result {
@@ -15575,15 +15881,23 @@ impl WatchIngestBatchOutcome {
     }
 }
 
+fn reborrow_optional_tantivy_index<'outer>(
+    index: &'outer mut Option<&mut TantivyIndex>,
+) -> Option<&'outer mut TantivyIndex> {
+    index.as_mut().map(|index| &mut **index)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn ingest_watch_batch_with_oom_split(
     storage: &FrankenStorage,
-    t_index: &mut TantivyIndex,
+    mut t_index: Option<&mut TantivyIndex>,
     data_dir: &Path,
     convs: &[NormalizedConversation],
     progress: &Option<Arc<IndexingProgress>>,
+    lexical_strategy: LexicalPopulationStrategy,
     defer_checkpoints: bool,
     capture_semantic_delta: bool,
+    insert_options: InsertConversationsOptions,
 ) -> Result<WatchIngestBatchOutcome> {
     debug_assert!(!convs.is_empty());
 
@@ -15593,13 +15907,14 @@ fn ingest_watch_batch_with_oom_split(
         let mut semantic_delta = WatchSemanticDelta::default();
         ingest_batch_with_semantic_delta(
             storage,
-            Some(t_index),
+            reborrow_optional_tantivy_index(&mut t_index),
             data_dir,
             convs,
             progress,
-            LexicalPopulationStrategy::IncrementalInline,
+            lexical_strategy,
             defer_checkpoints,
             capture_semantic_delta.then_some(&mut semantic_delta),
+            insert_options,
         )
     };
 
@@ -15621,21 +15936,25 @@ fn ingest_watch_batch_with_oom_split(
             );
             let mut merged = ingest_watch_batch_with_oom_split(
                 storage,
-                t_index,
+                reborrow_optional_tantivy_index(&mut t_index),
                 data_dir,
                 &convs[..split_at],
                 progress,
+                lexical_strategy,
                 defer_checkpoints,
                 capture_semantic_delta,
+                insert_options,
             )?;
             let right = ingest_watch_batch_with_oom_split(
                 storage,
-                t_index,
+                reborrow_optional_tantivy_index(&mut t_index),
                 data_dir,
                 &convs[split_at..],
                 progress,
+                lexical_strategy,
                 defer_checkpoints,
                 capture_semantic_delta,
+                insert_options,
             )?;
             merged.merge(right);
             Ok(merged)
@@ -15794,10 +16113,14 @@ fn build_watch_roots(additional_scan_roots: Vec<ScanRoot>) -> Vec<(ConnectorKind
         }
     }
 
-    // Add explicitly configured roots for ALL connectors.
+    // Add explicitly configured roots for every plausible connector. Remote
+    // mirrors may be mixed-provider, but local aimux/provider roots should not
+    // cause unrelated connectors to scan their global defaults.
     for configured_root in additional_scan_roots {
         for kind in &all_kinds {
-            roots.push((*kind, configured_root.clone()));
+            if additional_scan_root_matches_kind(*kind, &configured_root) {
+                roots.push((*kind, configured_root.clone()));
+            }
         }
     }
 
@@ -15964,6 +16287,7 @@ fn watch_sources<F: Fn(Vec<PathBuf>, &[(ConnectorKind, ScanRoot)], bool) -> Resu
     .iter()
     .find_map(|d| Instant::now().checked_sub(*d))
     .unwrap_or_else(Instant::now);
+    let startup_ignore_until = Instant::now() + min_scan_interval;
 
     tracing::info!(
         watch_interval_secs,
@@ -16006,6 +16330,13 @@ fn watch_sources<F: Fn(Vec<PathBuf>, &[(ConnectorKind, ScanRoot)], bool) -> Resu
 
         match rx.recv_timeout(timeout) {
             Ok(IndexerEvent::Notify(paths)) => {
+                if should_ignore_watch_startup_notification(Instant::now(), startup_ignore_until) {
+                    tracing::debug!(
+                        path_count = paths.len(),
+                        "ignoring watch notification during startup warmup"
+                    );
+                    continue;
+                }
                 if pending.is_empty() {
                     first_event = Some(Instant::now());
                 }
@@ -16149,12 +16480,15 @@ fn reindex_paths_with_semantic_delta(
     // DO NOT lock storage/index here for the whole duration.
     // We only need them for the ingest phase, not the scan phase.
 
+    let explicit_watch_once = opts
+        .watch_once_paths
+        .as_ref()
+        .is_some_and(|paths| !paths.is_empty());
     let triggers = classify_paths(
         paths,
         roots,
-        opts.watch_once_paths
-            .as_ref()
-            .is_some_and(|paths| !paths.is_empty()),
+        explicit_watch_once || opts.watch,
+        opts.watch && !explicit_watch_once,
     );
     if triggers.is_empty() {
         return Ok(0);
@@ -16179,10 +16513,6 @@ fn reindex_paths_with_semantic_delta(
             p.phase.store(1, Ordering::Relaxed);
         }
 
-        let explicit_watch_once = opts
-            .watch_once_paths
-            .as_ref()
-            .is_some_and(|paths| !paths.is_empty());
         let lexical_strategy_reason = if explicit_watch_once {
             "watch_once_targeted_reindex_applies_inline_lexical_updates_for_changed_paths"
         } else {
@@ -16217,14 +16547,17 @@ fn reindex_paths_with_semantic_delta(
                 .lock()
                 .map_err(|_| anyhow::anyhow!("state lock poisoned"))?;
             let previous_ts = guard.get(&kind).copied();
-            match (previous_ts, min_ts) {
-                // No previous watermark and no trigger timestamp: full scan this root.
-                (None, None) => None,
-                // Only one side available: use it.
-                (Some(ts), None) | (None, Some(ts)) => Some(ts.saturating_sub(1)),
-                // Use the older timestamp so out-of-order file events are not skipped.
-                (Some(prev), Some(batch_min)) => Some(prev.min(batch_min).saturating_sub(1)),
+            if opts.watch && should_skip_steady_watch_trigger(previous_ts, max_ts) {
+                tracing::debug!(
+                    ?kind,
+                    scan_root = %root.path.display(),
+                    previous_ts,
+                    max_ts,
+                    "skipping stale watch trigger before connector scan"
+                );
+                continue;
             }
+            watch_incremental_since_ts(previous_ts, min_ts)
         };
 
         // Use explicit root context
@@ -16311,16 +16644,34 @@ fn reindex_paths_with_semantic_delta(
             let mut t_index_guard = t_index
                 .lock()
                 .map_err(|_| anyhow::anyhow!("index lock poisoned"))?;
-            if t_index_guard.is_none() {
+            let use_inline_tantivy = !opts.watch || watch_inline_tantivy_enabled();
+            if use_inline_tantivy && t_index_guard.is_none() {
                 tracing::info!(
                     index_path = %index_path.display(),
                     "opening Tantivy lazily for watch ingest"
                 );
                 *t_index_guard = Some(TantivyIndex::open_or_create(index_path)?);
             }
-            let t_index = t_index_guard
-                .as_mut()
-                .expect("lazy watch index must be open before ingest");
+            let lexical_strategy = if use_inline_tantivy {
+                LexicalPopulationStrategy::IncrementalInline
+            } else {
+                tracing::info!(
+                    ?kind,
+                    conversations = conv_count,
+                    "skipping inline Tantivy update for watch ingest"
+                );
+                LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild
+            };
+            let insert_options = if opts.watch && !use_inline_tantivy {
+                tracing::info!(
+                    ?kind,
+                    conversations = conv_count,
+                    "deferring storage FTS and analytics updates for watch ingest"
+                );
+                InsertConversationsOptions::defer_derived_updates()
+            } else {
+                InsertConversationsOptions::from_env()
+            };
 
             let ingest_chunk_size = if explicit_watch_once {
                 conv_count.max(1)
@@ -16331,12 +16682,14 @@ fn reindex_paths_with_semantic_delta(
             for chunk in convs.chunks(ingest_chunk_size) {
                 let chunk_outcome = ingest_watch_batch_with_oom_split(
                     &storage,
-                    t_index,
+                    t_index_guard.as_mut(),
                     &opts.data_dir,
                     chunk,
                     &opts.progress,
+                    lexical_strategy,
                     !opts.watch,
                     capture_semantic_delta,
+                    insert_options,
                 )?;
                 inserted_messages =
                     inserted_messages.saturating_add(chunk_outcome.batch_outcome.inserted_messages);
@@ -16354,7 +16707,9 @@ fn reindex_paths_with_semantic_delta(
                 // Commit each successful chunk before advancing the partial
                 // watch watermark. A crash after this point replays at worst
                 // the next unfinished chunk, not the entire backlog.
-                t_index.commit()?;
+                if let Some(t_index) = t_index_guard.as_mut() {
+                    t_index.commit()?;
+                }
 
                 // Keep last_indexed_at current so `cass status` doesn't report stale during watch mode.
                 persist::with_ephemeral_writer(
@@ -16368,6 +16723,10 @@ fn reindex_paths_with_semantic_delta(
                 {
                     save_watch_state_watermark(&opts.data_dir, state, kind, ts_val)?;
                 }
+            }
+            if opts.watch && t_index_guard.is_some() {
+                tracing::debug!("closing Tantivy writer after watch ingest commit");
+                *t_index_guard = None;
             }
         }
         let index_ms = index_start.elapsed().as_millis() as u64;
@@ -16551,6 +16910,32 @@ fn load_watch_state(data_dir: &Path) -> HashMap<ConnectorKind, i64> {
         return map;
     }
     HashMap::new()
+}
+
+fn seed_watch_state_for_steady_watch(
+    data_dir: &Path,
+    state: &mut HashMap<ConnectorKind, i64>,
+    roots: &[(ConnectorKind, ScanRoot)],
+    now_ms: i64,
+) -> Result<bool> {
+    let mut changed = false;
+    for (kind, _) in roots {
+        match state.get_mut(kind) {
+            Some(ts) if *ts < now_ms => {
+                *ts = now_ms;
+                changed = true;
+            }
+            Some(_) => {}
+            None => {
+                state.insert(*kind, now_ms);
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        save_watch_state(data_dir, state)?;
+    }
+    Ok(changed)
 }
 
 fn replace_file_from_temp(temp_path: &Path, final_path: &Path) -> Result<()> {
@@ -16778,6 +17163,7 @@ fn classify_paths(
     paths: Vec<PathBuf>,
     roots: &[(ConnectorKind, ScanRoot)],
     prefer_explicit_paths: bool,
+    ignore_directory_paths: bool,
 ) -> Vec<(ConnectorKind, ScanRoot, Option<i64>, Option<i64>)> {
     // Key -> (Root, MinTS, MaxTS)
     let mut batch_map: BatchClassificationMap = HashMap::new();
@@ -16787,6 +17173,7 @@ fn classify_paths(
             .then(|| explicit_watch_once_connector_hint(&p))
             .flatten();
         if let Ok(meta) = std::fs::metadata(&p)
+            && !(ignore_directory_paths && meta.is_dir())
             && let Ok(time) = meta.modified()
             && let Ok(dur) = time.duration_since(std::time::UNIX_EPOCH)
         {
@@ -16949,6 +17336,123 @@ fn expand_local_scan_root_path(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+fn push_existing_local_scan_root(roots: &mut Vec<ScanRoot>, path: PathBuf) {
+    if !path.exists() || roots.iter().any(|root| root.path == path) {
+        return;
+    }
+    roots.push(ScanRoot::local(path));
+}
+
+fn append_aimux_codex_profile_roots(roots: &mut Vec<ScanRoot>, aimux_root: &Path) {
+    let codex_root = aimux_root.join("codex");
+    push_existing_local_scan_root(roots, codex_root.join("sessions"));
+
+    let Ok(entries) = fs::read_dir(&codex_root) else {
+        return;
+    };
+
+    let mut session_roots = entries
+        .flatten()
+        .map(|entry| entry.path().join("sessions"))
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    session_roots.sort();
+
+    for session_root in session_roots {
+        push_existing_local_scan_root(roots, session_root);
+    }
+}
+
+fn append_aimux_claude_profile_roots(roots: &mut Vec<ScanRoot>, aimux_root: &Path) {
+    let claude_root = aimux_root.join("claude");
+    push_existing_local_scan_root(roots, claude_root.join("projects"));
+    push_existing_local_scan_root(roots, claude_root.join(".claude/projects"));
+
+    let Ok(entries) = fs::read_dir(&claude_root) else {
+        return;
+    };
+
+    let mut project_roots = Vec::new();
+    for entry in entries.flatten() {
+        let profile_root = entry.path();
+        project_roots.push(profile_root.join("projects"));
+        project_roots.push(profile_root.join(".claude/projects"));
+    }
+    project_roots.retain(|path| path.exists());
+    project_roots.sort();
+
+    for project_root in project_roots {
+        push_existing_local_scan_root(roots, project_root);
+    }
+}
+
+fn append_aimux_gemini_profile_roots(roots: &mut Vec<ScanRoot>, aimux_root: &Path) {
+    let gemini_root = aimux_root.join("gemini");
+    if gemini_root.join(".gemini/tmp").exists() {
+        push_existing_local_scan_root(roots, gemini_root.clone());
+    }
+
+    let Ok(entries) = fs::read_dir(&gemini_root) else {
+        return;
+    };
+
+    let mut profile_roots = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.join(".gemini/tmp").exists())
+        .collect::<Vec<_>>();
+    profile_roots.sort();
+
+    for profile_root in profile_roots {
+        push_existing_local_scan_root(roots, profile_root);
+    }
+}
+
+fn append_aimux_opencode_roots(roots: &mut Vec<ScanRoot>, aimux_root: &Path) {
+    let opencode_root = aimux_root.join("opencode");
+    if opencode_root.join("opencode.db").exists() || opencode_root.join("storage").exists() {
+        push_existing_local_scan_root(roots, opencode_root.clone());
+    }
+
+    let Ok(entries) = fs::read_dir(&opencode_root) else {
+        return;
+    };
+
+    let mut profile_roots = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.join("opencode.db").exists() || path.join("storage").exists())
+        .collect::<Vec<_>>();
+    profile_roots.sort();
+
+    for profile_root in profile_roots {
+        push_existing_local_scan_root(roots, profile_root);
+    }
+}
+
+fn default_local_agent_scan_roots_for_home(home: &Path) -> Vec<ScanRoot> {
+    let mut roots = Vec::new();
+    let aimux_root = home.join(".aimux");
+
+    append_aimux_codex_profile_roots(&mut roots, &aimux_root);
+    append_aimux_claude_profile_roots(&mut roots, &aimux_root);
+    append_aimux_gemini_profile_roots(&mut roots, &aimux_root);
+    append_aimux_opencode_roots(&mut roots, &aimux_root);
+
+    push_existing_local_scan_root(&mut roots, home.join(".local/share/opencode"));
+    push_existing_local_scan_root(&mut roots, home.join(".config/opencode"));
+    push_existing_local_scan_root(&mut roots, home.join(".opencode"));
+
+    roots
+}
+
+fn default_local_agent_scan_roots() -> Vec<ScanRoot> {
+    dirs::home_dir()
+        .as_deref()
+        .map(default_local_agent_scan_roots_for_home)
+        .unwrap_or_default()
+}
+
 /// Build a list of scan roots for multi-root indexing.
 ///
 /// This function collects both:
@@ -16978,6 +17482,7 @@ pub fn build_scan_roots(storage: &FrankenStorage, data_dir: &Path) -> Vec<ScanRo
     // Connectors will use their own default detection logic when given an empty scan_roots.
     // For explicit multi-root support, we add the local root.
     roots.push(ScanRoot::local(data_dir.to_path_buf()));
+    roots.extend(default_local_agent_scan_roots());
 
     if dotenvy::var("CASS_IGNORE_SOURCES_CONFIG").is_err()
         && let Ok(config) = SourcesConfig::load()
@@ -17424,13 +17929,14 @@ fn capture_scan_root_file_before_parse(data_dir: &Path, provider: &str, root: &S
 fn attach_raw_mirror_capture(data_dir: &Path, conv: &mut NormalizedConversation) {
     let (source_id, origin_kind, origin_host) = raw_mirror_origin_from_metadata(&conv.metadata);
     let db_link = raw_mirror_db_link_for_conversation(conv);
+    let source_path = raw_mirror_capture_path_for_conversation(conv);
     match crate::raw_mirror::capture_source_file(crate::raw_mirror::RawMirrorCaptureInput {
         data_dir,
         provider: &conv.agent_slug,
         source_id: &source_id,
         origin_kind: &origin_kind,
         origin_host: origin_host.as_deref(),
-        source_path: &conv.source_path,
+        source_path: &source_path,
         db_links: std::slice::from_ref(&db_link),
     }) {
         Ok(record) => {
@@ -17454,6 +17960,26 @@ fn attach_raw_mirror_capture(data_dir: &Path, conv: &mut NormalizedConversation)
             );
         }
     }
+}
+
+fn raw_mirror_capture_path_for_conversation(conv: &NormalizedConversation) -> PathBuf {
+    if conv.source_path.exists() {
+        return conv.source_path.clone();
+    }
+
+    let Some(parent) = conv.source_path.parent() else {
+        return conv.source_path.clone();
+    };
+    if parent.is_file()
+        && parent
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("db"))
+    {
+        return parent.to_path_buf();
+    }
+
+    conv.source_path.clone()
 }
 
 fn raw_mirror_db_link_for_conversation(
@@ -17687,7 +18213,9 @@ pub mod persist {
     use crate::search::tantivy::TantivyIndex;
     #[cfg(test)]
     use crate::sources::provenance::{Source, SourceKind};
-    use crate::storage::sqlite::{FrankenStorage, IndexingCache, InsertOutcome};
+    use crate::storage::sqlite::{
+        FrankenStorage, IndexingCache, InsertConversationsOptions, InsertOutcome,
+    };
 
     /// `coding_agent_session_search-5b9p0` (ibuuh.32 follow-up):
     /// builds a [`ConversationPacket`] for the lexical sink AND the
@@ -18933,10 +19461,13 @@ pub mod persist {
             storage,
             t_index,
             convs,
-            lexical_strategy,
-            defer_checkpoints,
-            false,
-            None,
+            PersistConversationsBatchOptions {
+                lexical_strategy,
+                defer_checkpoints,
+                insert_options: InsertConversationsOptions::from_env(),
+                capture_semantic_delta: false,
+                raw_mirror_data_dir: None,
+            },
         )
     }
 
@@ -18947,15 +19478,19 @@ pub mod persist {
         convs: &[NormalizedConversation],
         lexical_strategy: LexicalPopulationStrategy,
         defer_checkpoints: bool,
+        insert_options: InsertConversationsOptions,
     ) -> Result<PersistBatchOutcome> {
         persist_conversations_batched_inner(
             storage,
             t_index,
             convs,
-            lexical_strategy,
-            defer_checkpoints,
-            false,
-            Some(data_dir),
+            PersistConversationsBatchOptions {
+                lexical_strategy,
+                defer_checkpoints,
+                insert_options,
+                capture_semantic_delta: false,
+                raw_mirror_data_dir: Some(data_dir),
+            },
         )
     }
 
@@ -18966,40 +19501,51 @@ pub mod persist {
         convs: &[NormalizedConversation],
         lexical_strategy: LexicalPopulationStrategy,
         defer_checkpoints: bool,
+        insert_options: InsertConversationsOptions,
     ) -> Result<PersistBatchOutcome> {
         persist_conversations_batched_inner(
             storage,
             t_index,
             convs,
-            lexical_strategy,
-            defer_checkpoints,
-            true,
-            Some(data_dir),
+            PersistConversationsBatchOptions {
+                lexical_strategy,
+                defer_checkpoints,
+                insert_options,
+                capture_semantic_delta: true,
+                raw_mirror_data_dir: Some(data_dir),
+            },
         )
+    }
+
+    struct PersistConversationsBatchOptions<'a> {
+        lexical_strategy: LexicalPopulationStrategy,
+        defer_checkpoints: bool,
+        insert_options: InsertConversationsOptions,
+        capture_semantic_delta: bool,
+        raw_mirror_data_dir: Option<&'a Path>,
     }
 
     fn persist_conversations_batched_inner(
         storage: &FrankenStorage,
         mut t_index: Option<&mut TantivyIndex>,
         convs: &[NormalizedConversation],
-        lexical_strategy: LexicalPopulationStrategy,
-        defer_checkpoints: bool,
-        capture_semantic_delta: bool,
-        raw_mirror_data_dir: Option<&Path>,
+        options: PersistConversationsBatchOptions<'_>,
     ) -> Result<PersistBatchOutcome> {
         if convs.is_empty() {
             return Ok(PersistBatchOutcome::default());
         }
-        if lexical_population_strategy_requires_inline_tantivy(lexical_strategy)
+        if lexical_population_strategy_requires_inline_tantivy(options.lexical_strategy)
             && t_index.is_none()
         {
             anyhow::bail!(
                 "batched persistence requires a Tantivy writer for {}",
-                lexical_strategy.as_str()
+                options.lexical_strategy.as_str()
             );
         }
 
-        let begin_concurrent_enabled = begin_concurrent_writes_enabled();
+        let begin_concurrent_enabled = begin_concurrent_writes_enabled()
+            && !(options.insert_options.defer_lexical_updates
+                || options.insert_options.defer_analytics_updates);
         let duplicate_keys_present =
             begin_concurrent_enabled && duplicate_conversation_keys_present(convs);
 
@@ -19016,10 +19562,10 @@ pub mod persist {
                 &db_path,
                 t_index,
                 convs,
-                lexical_strategy,
-                defer_checkpoints,
-                capture_semantic_delta,
-                raw_mirror_data_dir,
+                options.lexical_strategy,
+                options.defer_checkpoints,
+                options.capture_semantic_delta,
+                options.raw_mirror_data_dir,
             );
         }
 
@@ -19048,7 +19594,7 @@ pub mod persist {
 
         let outcomes = with_ephemeral_writer(
             storage,
-            defer_checkpoints,
+            options.defer_checkpoints,
             "serial batched indexing",
             |writer| {
                 let cache_enabled = IndexingCache::is_enabled();
@@ -19106,7 +19652,10 @@ pub mod persist {
                 for start in (0..refs.len()).step_by(chunk_size) {
                     let end = (start + chunk_size).min(refs.len());
                     let chunk_refs = &refs[start..end];
-                    outcomes.extend(writer.insert_conversations_batched(chunk_refs)?);
+                    outcomes.extend(writer.insert_conversations_batched_with_options(
+                        chunk_refs,
+                        options.insert_options,
+                    )?);
                 }
 
                 Ok(outcomes)
@@ -19114,7 +19663,7 @@ pub mod persist {
         )?;
         let defer_lexical_updates = defer_lexical_updates_enabled();
         let mut batch_outcome = PersistBatchOutcome::default();
-        record_persisted_raw_mirror_db_links(raw_mirror_data_dir, convs, &outcomes);
+        record_persisted_raw_mirror_db_links(options.raw_mirror_data_dir, convs, &outcomes);
         if !defer_lexical_updates {
             // ibuuh.32 / 5b9p0: route the serial-batched lexical sink
             // through the packet pipeline. Build each packet ONCE and
@@ -19123,7 +19672,7 @@ pub mod persist {
             // from outcome.inserted_indices).
             for (conv, outcome) in convs.iter().zip(outcomes.iter()) {
                 batch_outcome.record_insert_outcome(outcome);
-                match lexical_strategy {
+                match options.lexical_strategy {
                     LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild => continue,
                     LexicalPopulationStrategy::InlineRebuildFromScan => {
                         let packet = lexical_packet_for_persist(conv);
@@ -19163,7 +19712,7 @@ pub mod persist {
             }
         }
 
-        if capture_semantic_delta {
+        if options.capture_semantic_delta {
             for outcome in outcomes.iter() {
                 let (inputs, max_message_id) = packet_semantic_delta_for_outcome(storage, outcome)?;
                 batch_outcome.extend_semantic_delta(inputs, max_message_id);
@@ -20062,7 +20611,7 @@ pub mod persist {
         }
 
         #[test]
-        fn incremental_canonical_lexical_repair_plan_prefers_authoritative_db_for_sparse_tantivy() {
+        fn incremental_canonical_lexical_repair_plan_prefers_authoritative_db_for_empty_tantivy() {
             assert_eq!(
                 crate::indexer::choose_incremental_canonical_lexical_repair_plan(
                     crate::indexer::IncrementalCanonicalLexicalRepairContext {
@@ -20073,12 +20622,12 @@ pub mod persist {
                         salvage_messages_imported: 0,
                         canonical_messages: 42,
                         tantivy_requires_rebuild: false,
-                        observed_tantivy_docs: Some(3),
+                        observed_tantivy_docs: Some(0),
                     },
                 ),
                 Some(crate::indexer::IncrementalCanonicalLexicalRepairPlan {
                     canonical_messages: 42,
-                    observed_tantivy_docs: Some(3),
+                    observed_tantivy_docs: Some(0),
                     reason: "incremental_index_repairs_sparse_tantivy_from_authoritative_canonical_db_before_scan",
                 })
             );
@@ -20140,6 +20689,25 @@ pub mod persist {
                         canonical_messages: 42,
                         tantivy_requires_rebuild: false,
                         observed_tantivy_docs: Some(42),
+                    },
+                ),
+                None
+            );
+        }
+
+        #[test]
+        fn incremental_canonical_lexical_repair_plan_tolerates_filtered_doc_gap() {
+            assert_eq!(
+                crate::indexer::choose_incremental_canonical_lexical_repair_plan(
+                    crate::indexer::IncrementalCanonicalLexicalRepairContext {
+                        full_refresh: false,
+                        force_rebuild: false,
+                        resume_lexical_rebuild: false,
+                        targeted_watch_once_only: false,
+                        salvage_messages_imported: 0,
+                        canonical_messages: 42,
+                        tantivy_requires_rebuild: false,
+                        observed_tantivy_docs: Some(3),
                     },
                 ),
                 None
@@ -22026,6 +22594,73 @@ mod tests {
     }
 
     #[test]
+    fn raw_mirror_capture_uses_sqlite_parent_for_synthetic_session_paths() {
+        let temp = TempDir::new().expect("tempdir");
+        let data_dir = temp.path().join("cass-data");
+        let db_path = temp.path().join("opencode.db");
+        let db_bytes = b"sqlite fixture bytes";
+        std::fs::write(&db_path, db_bytes).expect("write sqlite fixture");
+        let synthetic_session_path = db_path.join("ses_fixture");
+
+        let mut conv = NormalizedConversation {
+            agent_slug: "opencode".to_string(),
+            external_id: Some("ses_fixture".to_string()),
+            title: Some("OpenCode sqlite session".to_string()),
+            workspace: None,
+            source_path: synthetic_session_path.clone(),
+            started_at: Some(1_733_000_000_000),
+            ended_at: Some(1_733_000_000_100),
+            metadata: serde_json::json!({
+                "session_id": "ses_fixture",
+                "source": "sqlite"
+            }),
+            messages: vec![NormalizedMessage {
+                idx: 0,
+                role: "user".to_string(),
+                author: None,
+                created_at: Some(1_733_000_000_000),
+                content: "hello from opencode".to_string(),
+                extra: serde_json::json!({}),
+                snippets: Vec::new(),
+                invocations: Vec::new(),
+            }],
+        };
+        inject_provenance(&mut conv, &Origin::local());
+
+        assert_eq!(raw_mirror_capture_path_for_conversation(&conv), db_path);
+        attach_raw_mirror_capture(&data_dir, &mut conv);
+
+        let manifest_root = data_dir.join("raw-mirror/v1/manifests");
+        let manifests = std::fs::read_dir(&manifest_root)
+            .expect("manifest dir")
+            .collect::<std::io::Result<Vec<_>>>()
+            .expect("manifest entries");
+        assert_eq!(manifests.len(), 1);
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(manifests[0].path()).expect("manifest bytes"))
+                .expect("manifest json");
+        assert_eq!(
+            manifest["original_path"].as_str(),
+            Some(db_path.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            manifest["db_links"][0]["source_path"].as_str(),
+            Some(synthetic_session_path.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            std::fs::read(
+                data_dir.join("raw-mirror/v1").join(
+                    manifest["blob_relative_path"]
+                        .as_str()
+                        .expect("blob relative path")
+                )
+            )
+            .expect("raw mirror blob"),
+            db_bytes
+        );
+    }
+
+    #[test]
     fn ingest_batch_records_persisted_raw_mirror_conversation_id_link() {
         let temp = TempDir::new().expect("tempdir");
         let data_dir = temp.path().join("cass-data");
@@ -22070,8 +22705,11 @@ mod tests {
             &data_dir,
             &[conv],
             &None,
-            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .expect("ingest batch");
         assert_eq!(mutations.inserted_conversations, 1);
@@ -22141,11 +22779,14 @@ mod tests {
             &storage,
             None,
             &opts,
-            None,
-            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
-            Vec::new(),
+            ScanRunOptions {
+                since_ts: None,
+                lexical_strategy: LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                insert_options: InsertConversationsOptions::from_env(),
+                additional_scan_roots: Vec::new(),
+                scan_start_ts: FrankenStorage::now_millis(),
+            },
             vec![("codex", failing_explicit_file_root_connector_factory)],
-            FrankenStorage::now_millis(),
         )
         .expect("failed scan should not abort batch indexing");
         *FAILING_EXPLICIT_FILE_ROOT
@@ -22278,6 +22919,12 @@ mod tests {
         EnvGuard { key, previous }
     }
 
+    fn isolate_scan_root_home(tmp: &Path) -> EnvGuard {
+        let home = tmp.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        set_env_var("HOME", home.to_string_lossy())
+    }
+
     fn never_constructed_connector_factory() -> Box<dyn Connector + Send> {
         panic!("test should not construct connector factories while filtering by config");
     }
@@ -22289,6 +22936,188 @@ mod tests {
             std::env::set_var(key, value);
         }
         EnvGuard { key, previous }
+    }
+
+    #[test]
+    #[serial]
+    fn source_scan_derived_deferral_is_opt_in_for_plain_incremental_source_scans() {
+        let _guard = set_env("CASS_INDEX_DEFER_DERIVED_UPDATES", "1");
+        let data_dir = PathBuf::from("/tmp/cass-derived-deferral");
+        let base = IndexOptions {
+            full: false,
+            force_rebuild: false,
+            watch: false,
+            watch_once_paths: None,
+            db_path: data_dir.join("agent_search.db"),
+            data_dir,
+            semantic: false,
+            build_hnsw: false,
+            embedder: "fastembed".to_string(),
+            progress: None,
+            watch_interval_secs: 30,
+        };
+
+        let incremental =
+            insert_options_for_source_scan(&base, LexicalPopulationStrategy::IncrementalInline);
+        assert!(incremental.defer_lexical_updates);
+        assert!(incremental.defer_analytics_updates);
+
+        let mut full = base.clone();
+        full.full = true;
+        let full_options =
+            insert_options_for_source_scan(&full, LexicalPopulationStrategy::IncrementalInline);
+        assert!(!full_options.defer_lexical_updates);
+        assert!(!full_options.defer_analytics_updates);
+
+        let deferred_authoritative = insert_options_for_source_scan(
+            &base,
+            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+        );
+        assert!(deferred_authoritative.defer_lexical_updates);
+        assert!(deferred_authoritative.defer_analytics_updates);
+
+        let rebuild =
+            insert_options_for_source_scan(&base, LexicalPopulationStrategy::InlineRebuildFromScan);
+        assert!(!rebuild.defer_lexical_updates);
+        assert!(!rebuild.defer_analytics_updates);
+    }
+
+    #[test]
+    #[serial]
+    fn source_scan_tantivy_deferral_uses_authoritative_rebuild_only_for_plain_incremental() {
+        let _guard = set_env("CASS_INDEX_DEFER_TANTIVY_UPDATES", "1");
+        let data_dir = PathBuf::from("/tmp/cass-tantivy-deferral");
+        let base = IndexOptions {
+            full: false,
+            force_rebuild: false,
+            watch: false,
+            watch_once_paths: None,
+            db_path: data_dir.join("agent_search.db"),
+            data_dir,
+            semantic: false,
+            build_hnsw: false,
+            embedder: "fastembed".to_string(),
+            progress: None,
+            watch_interval_secs: 30,
+        };
+
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&base, false, 0),
+            (
+                LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                "incremental_scan_defers_inline_tantivy_updates_to_authoritative_db_rebuild",
+            )
+        );
+        assert!(should_run_post_scan_authoritative_rebuild(
+            false,
+            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+            0
+        ));
+
+        let mut full = base.clone();
+        full.full = true;
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&full, false, 0),
+            (
+                LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                "full_refresh_defers_inline_lexical_writes_to_authoritative_db_rebuild",
+            )
+        );
+
+        let mut watch = base.clone();
+        watch.watch = true;
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&watch, false, 0),
+            (
+                LexicalPopulationStrategy::IncrementalInline,
+                "incremental_scan_applies_inline_lexical_updates_only_for_new_messages",
+            )
+        );
+
+        let mut force = base.clone();
+        force.force_rebuild = true;
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&force, false, 0),
+            (
+                LexicalPopulationStrategy::IncrementalInline,
+                "incremental_scan_applies_inline_lexical_updates_only_for_new_messages",
+            )
+        );
+
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&base, true, 0),
+            (
+                LexicalPopulationStrategy::InlineRebuildFromScan,
+                "lexical_index_needs_rebuild_so_scan_results_repopulate_tantivy_directly",
+            )
+        );
+        assert_eq!(
+            resolve_source_scan_lexical_population_strategy(&base, false, 7),
+            (
+                LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                "historical_salvage_imported_messages_require_authoritative_db_rebuild",
+            )
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn derived_deferral_preserves_incremental_tantivy_updates() {
+        let _lexical_guard = set_env("CASS_DEFER_LEXICAL_UPDATES", "0");
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let db_path = data_dir.join("agent_search.db");
+        let storage = FrankenStorage::open(&db_path).unwrap();
+        ensure_fts_schema(&storage);
+        let mut index = TantivyIndex::open_or_create(&index_dir(&data_dir).unwrap()).unwrap();
+        let convs = vec![norm_conv(
+            Some("defer-storage-keep-tantivy"),
+            vec![
+                norm_msg(0, 1_700_000_000_000),
+                norm_msg(1, 1_700_000_000_100),
+            ],
+        )];
+
+        let mutations = ingest_batch(
+            &storage,
+            Some(&mut index),
+            &data_dir,
+            &convs,
+            &None,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::defer_derived_updates(),
+            },
+        )
+        .unwrap();
+        index.commit().unwrap();
+        drop(index);
+
+        assert_eq!(
+            mutations,
+            CanonicalMutationCounts {
+                inserted_conversations: 1,
+                inserted_messages: 2,
+            }
+        );
+        assert_eq!(tantivy_doc_count_for_data_dir(&data_dir), 2);
+
+        let metrics_count: i64 = storage
+            .raw()
+            .query_row_map("SELECT COUNT(*) FROM message_metrics", &[], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        let token_usage_count: i64 = storage
+            .raw()
+            .query_row_map("SELECT COUNT(*) FROM token_usage", &[], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        assert_eq!(metrics_count, 0);
+        assert_eq!(token_usage_count, 0);
     }
 
     #[test]
@@ -27447,6 +28276,7 @@ mod tests {
             Arc::new(StreamingByteLimiter::new(STREAMING_MAX_BYTES_IN_FLIGHT)),
             &Some(progress.clone()),
             LexicalPopulationStrategy::IncrementalInline,
+            InsertConversationsOptions::from_env(),
             None,
         )
         .unwrap();
@@ -27457,6 +28287,69 @@ mod tests {
         assert_eq!(stats.agents_discovered, vec!["claude".to_string()]);
         assert_eq!(stats.total_conversations, 0);
         assert_eq!(stats.total_messages, 0);
+    }
+
+    #[test]
+    fn streaming_final_commit_is_skipped_for_zero_batch_scans() {
+        assert!(!should_commit_streaming_final_tantivy(0));
+        assert!(should_commit_streaming_final_tantivy(1));
+    }
+
+    #[test]
+    fn post_scan_commit_requires_canonical_mutations() {
+        assert!(!should_commit_tantivy_after_scan(
+            true,
+            CanonicalMutationCounts::default()
+        ));
+        assert!(!should_commit_tantivy_after_scan(
+            false,
+            CanonicalMutationCounts {
+                inserted_conversations: 1,
+                inserted_messages: 1,
+            }
+        ));
+        assert!(should_commit_tantivy_after_scan(
+            true,
+            CanonicalMutationCounts {
+                inserted_conversations: 0,
+                inserted_messages: 1,
+            }
+        ));
+    }
+
+    #[test]
+    fn watch_startup_broad_incremental_scan_is_skipped_when_index_is_ready() {
+        assert!(should_skip_watch_startup_broad_incremental_scan(
+            true, false, false, false, 0
+        ));
+        assert!(!should_skip_watch_startup_broad_incremental_scan(
+            false, false, false, false, 0
+        ));
+        assert!(!should_skip_watch_startup_broad_incremental_scan(
+            true, true, false, false, 0
+        ));
+        assert!(!should_skip_watch_startup_broad_incremental_scan(
+            true, false, true, false, 0
+        ));
+        assert!(!should_skip_watch_startup_broad_incremental_scan(
+            true, false, false, true, 0
+        ));
+        assert!(!should_skip_watch_startup_broad_incremental_scan(
+            true, false, false, false, 1
+        ));
+    }
+
+    #[test]
+    fn watch_startup_notifications_are_ignored_until_warmup_expires() {
+        let now = Instant::now();
+        assert!(should_ignore_watch_startup_notification(
+            now,
+            now + Duration::from_secs(1)
+        ));
+        assert!(!should_ignore_watch_startup_notification(
+            now + Duration::from_secs(1),
+            now + Duration::from_secs(1)
+        ));
     }
 
     #[test]
@@ -27495,6 +28388,7 @@ mod tests {
             Arc::new(StreamingByteLimiter::new(STREAMING_MAX_BYTES_IN_FLIGHT)),
             &Some(progress.clone()),
             LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+            InsertConversationsOptions::from_env(),
             Some(FrankenStorage::now_millis()),
         )
         .expect("deferred streaming ingest should not require a Tantivy writer");
@@ -27582,6 +28476,7 @@ mod tests {
             flow_limiter,
             &Some(progress.clone()),
             LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+            InsertConversationsOptions::from_env(),
             Some(FrankenStorage::now_millis()),
         )
         .expect("mixed startup ingest should not violate foreign keys");
@@ -27647,8 +28542,11 @@ mod tests {
             &data_dir,
             &first,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            true,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: true,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
 
@@ -27663,8 +28561,11 @@ mod tests {
             &data_dir,
             &second,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
 
@@ -27820,6 +28721,7 @@ mod tests {
             flow_limiter,
             &Some(progress.clone()),
             LexicalPopulationStrategy::IncrementalInline,
+            InsertConversationsOptions::from_env(),
             None,
         )
         .unwrap();
@@ -27924,6 +28826,7 @@ mod tests {
                 flow_limiter,
                 &Some(progress),
                 LexicalPopulationStrategy::IncrementalInline,
+                InsertConversationsOptions::from_env(),
                 None,
             )
             .unwrap();
@@ -28002,6 +28905,7 @@ mod tests {
             flow_limiter,
             &Some(progress.clone()),
             LexicalPopulationStrategy::IncrementalInline,
+            InsertConversationsOptions::from_env(),
             None,
         )
         .unwrap();
@@ -28048,6 +28952,7 @@ mod tests {
             flow_limiter,
             &Some(progress.clone()),
             LexicalPopulationStrategy::IncrementalInline,
+            InsertConversationsOptions::from_env(),
             None,
         )
         .unwrap();
@@ -28184,6 +29089,7 @@ mod tests {
             flow_limiter,
             &Some(progress.clone()),
             LexicalPopulationStrategy::IncrementalInline,
+            InsertConversationsOptions::from_env(),
             None,
         )
         .unwrap();
@@ -28233,11 +29139,14 @@ mod tests {
             &storage,
             Some(&mut index),
             &opts,
-            None,
-            LexicalPopulationStrategy::IncrementalInline,
-            Vec::new(),
+            ScanRunOptions {
+                since_ts: None,
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                insert_options: InsertConversationsOptions::from_env(),
+                additional_scan_roots: Vec::new(),
+                scan_start_ts: FrankenStorage::now_millis(),
+            },
             vec![("claude", panic_connector_factory)],
-            FrankenStorage::now_millis(),
         )
         .expect_err("producer panic should abort streaming indexing");
         let message = error.to_string();
@@ -28288,11 +29197,14 @@ mod tests {
             &storage,
             None,
             &opts,
-            None,
-            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
-            Vec::new(),
+            ScanRunOptions {
+                since_ts: None,
+                lexical_strategy: LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                insert_options: InsertConversationsOptions::from_env(),
+                additional_scan_roots: Vec::new(),
+                scan_start_ts: FrankenStorage::now_millis(),
+            },
             vec![("codex", deferred_batch_connector_factory)],
-            FrankenStorage::now_millis(),
         )
         .expect("deferred batch ingest should not require a Tantivy writer");
 
@@ -30553,8 +31465,11 @@ mod tests {
             &data_dir,
             &convs,
             &None,
-            LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::DeferredAuthoritativeDbRebuild,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
         drop(storage);
@@ -33037,7 +33952,7 @@ mod tests {
         ];
 
         let paths = vec![codex.clone(), claude.clone(), aider, cursor, chatgpt];
-        let classified = classify_paths(paths, &roots, false);
+        let classified = classify_paths(paths, &roots, false, false);
 
         let kinds: std::collections::HashSet<_> =
             classified.iter().map(|(k, _, _, _)| *k).collect();
@@ -33062,7 +33977,23 @@ mod tests {
 
         let roots = vec![(ConnectorKind::Claude, ScanRoot::local(project_root.clone()))];
 
-        let classified = classify_paths(vec![session.clone()], &roots, true);
+        let classified = classify_paths(vec![session.clone()], &roots, true, false);
+
+        assert_eq!(classified.len(), 1);
+        assert_eq!(classified[0].0, ConnectorKind::Claude);
+        assert_eq!(classified[0].1.path, session);
+    }
+
+    #[test]
+    fn classify_paths_can_ignore_directory_events_for_steady_watch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path().join("project");
+        let session = project_root.join("subagents").join("session.jsonl");
+        std::fs::create_dir_all(session.parent().unwrap()).unwrap();
+        std::fs::write(&session, b"{}").unwrap();
+
+        let roots = vec![(ConnectorKind::Claude, ScanRoot::local(project_root.clone()))];
+        let classified = classify_paths(vec![project_root, session.clone()], &roots, true, true);
 
         assert_eq!(classified.len(), 1);
         assert_eq!(classified[0].0, ConnectorKind::Claude);
@@ -33083,7 +34014,7 @@ mod tests {
             (ConnectorKind::Gemini, ScanRoot::local(codex_root)),
         ];
 
-        let classified = classify_paths(vec![session.clone()], &roots, true);
+        let classified = classify_paths(vec![session.clone()], &roots, true, false);
 
         assert_eq!(classified.len(), 1);
         assert_eq!(classified[0].0, ConnectorKind::Codex);
@@ -33103,7 +34034,7 @@ mod tests {
         std::fs::create_dir_all(session.parent().unwrap()).unwrap();
         std::fs::write(&session, b"{}").unwrap();
 
-        let classified = classify_paths(vec![session.clone()], &[], true);
+        let classified = classify_paths(vec![session.clone()], &[], true, false);
 
         assert_eq!(classified.len(), 1);
         assert_eq!(classified[0].0, ConnectorKind::Codex);
@@ -33396,6 +34327,108 @@ mod tests {
         assert!(raw.contains("\"m\""));
         assert!(raw.contains("\"cx\""));
         assert!(!raw.contains("Codex"));
+    }
+
+    #[test]
+    fn watch_incremental_since_ts_prefers_saved_watermark() {
+        assert_eq!(
+            watch_incremental_since_ts(Some(10_000), Some(1_000)),
+            Some(9_999)
+        );
+        assert_eq!(watch_incremental_since_ts(Some(10_000), None), Some(9_999));
+        assert_eq!(watch_incremental_since_ts(None, Some(1_000)), Some(999));
+        assert_eq!(watch_incremental_since_ts(None, None), None);
+    }
+
+    #[test]
+    fn steady_watch_trigger_skip_uses_saved_high_watermark() {
+        assert!(should_skip_steady_watch_trigger(Some(10_000), Some(9_999)));
+        assert!(!should_skip_steady_watch_trigger(
+            Some(10_000),
+            Some(10_000)
+        ));
+        assert!(!should_skip_steady_watch_trigger(Some(10_000), None));
+        assert!(!should_skip_steady_watch_trigger(None, Some(9_999)));
+    }
+
+    #[test]
+    #[serial]
+    fn watch_inline_tantivy_is_opt_in() {
+        let prev = dotenvy::var("CASS_WATCH_INLINE_TANTIVY").ok();
+        unsafe { std::env::remove_var("CASS_WATCH_INLINE_TANTIVY") };
+        assert!(!watch_inline_tantivy_enabled());
+
+        unsafe { std::env::set_var("CASS_WATCH_INLINE_TANTIVY", "1") };
+        assert!(watch_inline_tantivy_enabled());
+
+        unsafe { std::env::set_var("CASS_WATCH_INLINE_TANTIVY", "false") };
+        assert!(!watch_inline_tantivy_enabled());
+
+        if let Some(prev) = prev {
+            unsafe { std::env::set_var("CASS_WATCH_INLINE_TANTIVY", prev) };
+        } else {
+            unsafe { std::env::remove_var("CASS_WATCH_INLINE_TANTIVY") };
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn watch_opencode_is_opt_in() {
+        let prev = dotenvy::var("CASS_WATCH_OPENCODE").ok();
+        unsafe { std::env::remove_var("CASS_WATCH_OPENCODE") };
+        assert!(!watch_opencode_enabled());
+
+        unsafe { std::env::set_var("CASS_WATCH_OPENCODE", "true") };
+        assert!(watch_opencode_enabled());
+
+        unsafe { std::env::set_var("CASS_WATCH_OPENCODE", "0") };
+        assert!(!watch_opencode_enabled());
+
+        if let Some(prev) = prev {
+            unsafe { std::env::set_var("CASS_WATCH_OPENCODE", prev) };
+        } else {
+            unsafe { std::env::remove_var("CASS_WATCH_OPENCODE") };
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn watch_state_seed_advances_connector_watermarks_for_steady_watch() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let mut state = HashMap::new();
+        state.insert(ConnectorKind::Amp, 50);
+        state.insert(ConnectorKind::Codex, 5_000);
+        let roots = vec![
+            (ConnectorKind::Amp, ScanRoot::local(tmp.path().join("amp"))),
+            (
+                ConnectorKind::Codex,
+                ScanRoot::local(tmp.path().join("codex")),
+            ),
+            (
+                ConnectorKind::Claude,
+                ScanRoot::local(tmp.path().join("claude")),
+            ),
+        ];
+
+        let changed =
+            seed_watch_state_for_steady_watch(&data_dir, &mut state, &roots, 1_000).unwrap();
+        assert!(changed);
+
+        assert_eq!(state.get(&ConnectorKind::Amp), Some(&1_000));
+        assert_eq!(state.get(&ConnectorKind::Codex), Some(&5_000));
+        assert_eq!(state.get(&ConnectorKind::Claude), Some(&1_000));
+
+        let loaded = load_watch_state(&data_dir);
+        assert_eq!(loaded.get(&ConnectorKind::Amp), Some(&1_000));
+        assert_eq!(loaded.get(&ConnectorKind::Codex), Some(&5_000));
+        assert_eq!(loaded.get(&ConnectorKind::Claude), Some(&1_000));
+
+        let unchanged =
+            seed_watch_state_for_steady_watch(&data_dir, &mut state, &roots, 900).unwrap();
+        assert!(!unchanged);
     }
 
     #[test]
@@ -33748,9 +34781,9 @@ mod tests {
 
     #[test]
     #[serial]
-    fn reindex_paths_uses_oldest_trigger_window_when_state_is_newer() {
+    fn reindex_paths_prefers_watch_state_watermark_over_stale_trigger_mtime() {
         let tmp = TempDir::new().unwrap();
-        let xdg = tmp.path().join("xdg_oldest_window");
+        let xdg = tmp.path().join("xdg_watch_state_watermark");
         std::fs::create_dir_all(&xdg).unwrap();
         let prev = dotenvy::var("XDG_DATA_HOME").ok();
         unsafe { std::env::set_var("XDG_DATA_HOME", &xdg) };
@@ -33776,7 +34809,7 @@ mod tests {
 
         let opts = super::IndexOptions {
             full: false,
-            watch: false,
+            watch: true,
             force_rebuild: false,
             watch_once_paths: None,
             db_path: data_dir.join("db.sqlite"),
@@ -33790,12 +34823,11 @@ mod tests {
 
         let storage = FrankenStorage::open(&opts.db_path).unwrap();
         let index_path = index_dir(&opts.data_dir).unwrap();
-        let t_index = TantivyIndex::open_or_create(&index_path).unwrap();
         let mut initial = HashMap::new();
         initial.insert(ConnectorKind::Amp, i64::MAX / 4);
         let state = Mutex::new(initial);
         let storage = Mutex::new(storage);
-        let t_index = Mutex::new(Some(t_index));
+        let t_index = Mutex::new(None);
         let roots = vec![(ConnectorKind::Amp, ScanRoot::local(amp_dir))];
 
         let indexed = reindex_paths(
@@ -33809,9 +34841,13 @@ mod tests {
             false,
         )
         .unwrap();
+        assert_eq!(
+            indexed, 0,
+            "stale trigger mtimes must not backfill before the saved watch high-water mark"
+        );
         assert!(
-            indexed > 0,
-            "expected indexing to use trigger min_ts instead of stale future watch-state"
+            t_index.lock().unwrap().is_none(),
+            "stale event scans with no conversations must not open Tantivy"
         );
 
         if let Some(prev) = prev {
@@ -33898,6 +34934,115 @@ mod tests {
             unsafe { std::env::set_var("XDG_DATA_HOME", prev) };
         } else {
             unsafe { std::env::remove_var("XDG_DATA_HOME") };
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn reindex_paths_watch_mode_ingests_without_opening_tantivy_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = tmp.path().join("xdg_watch_no_inline_tantivy");
+        std::fs::create_dir_all(&xdg).unwrap();
+        let prev_xdg = dotenvy::var("XDG_DATA_HOME").ok();
+        let prev_inline = dotenvy::var("CASS_WATCH_INLINE_TANTIVY").ok();
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", &xdg);
+            std::env::remove_var("CASS_WATCH_INLINE_TANTIVY");
+        }
+
+        let data_dir = xdg.join("amp");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let amp_dir = data_dir.join("amp");
+        std::fs::create_dir_all(&amp_dir).unwrap();
+        let amp_file = amp_dir.join("thread-watch-no-tantivy.json");
+        let now = FrankenStorage::now_millis().saturating_add(10_000);
+        std::fs::write(
+            &amp_file,
+            format!(
+                r#"{{"id":"twnt","messages":[{{"role":"user","text":"p","createdAt":{now}}}]}}"#
+            ),
+        )
+        .unwrap();
+
+        let opts = super::IndexOptions {
+            full: false,
+            watch: true,
+            force_rebuild: false,
+            watch_once_paths: None,
+            db_path: data_dir.join("db.sqlite"),
+            data_dir: data_dir.clone(),
+            semantic: false,
+            build_hnsw: false,
+            embedder: "fastembed".to_string(),
+            progress: None,
+            watch_interval_secs: 30,
+        };
+
+        let storage = FrankenStorage::open(&opts.db_path).unwrap();
+        let index_path = index_dir(&opts.data_dir).unwrap();
+        let state = Mutex::new(HashMap::new());
+        let storage = Mutex::new(storage);
+        let t_index = Mutex::new(None);
+        let roots = vec![(ConnectorKind::Amp, ScanRoot::local(amp_dir))];
+
+        let indexed = reindex_paths(
+            &opts,
+            vec![amp_file],
+            &roots,
+            &state,
+            &storage,
+            &t_index,
+            &index_path,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(indexed, 1);
+        assert!(
+            t_index.lock().unwrap().is_none(),
+            "default watch ingest must not open Tantivy inline"
+        );
+        assert!(
+            storage
+                .lock()
+                .unwrap()
+                .get_last_indexed_at()
+                .unwrap()
+                .is_some(),
+            "watch ingest should still advance status freshness after canonical persistence"
+        );
+        let storage_guard = storage.lock().unwrap();
+        let metrics_count: i64 = storage_guard
+            .raw()
+            .query_row_map("SELECT COUNT(*) FROM message_metrics", &[], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        let token_usage_count: i64 = storage_guard
+            .raw()
+            .query_row_map("SELECT COUNT(*) FROM token_usage", &[], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        assert_eq!(
+            metrics_count, 0,
+            "default watch ingest should defer analytics rows out of the foreground transaction"
+        );
+        assert_eq!(
+            token_usage_count, 0,
+            "default watch ingest should defer token usage rows out of the foreground transaction"
+        );
+        drop(storage_guard);
+
+        if let Some(prev) = prev_xdg {
+            unsafe { std::env::set_var("XDG_DATA_HOME", prev) };
+        } else {
+            unsafe { std::env::remove_var("XDG_DATA_HOME") };
+        }
+        if let Some(prev) = prev_inline {
+            unsafe { std::env::set_var("CASS_WATCH_INLINE_TANTIVY", prev) };
+        } else {
+            unsafe { std::env::remove_var("CASS_WATCH_INLINE_TANTIVY") };
         }
     }
 
@@ -34467,6 +35612,7 @@ mod tests {
     fn build_scan_roots_creates_local_root() {
         let _guard = ignore_sources_config();
         let tmp = TempDir::new().unwrap();
+        let _home_guard = isolate_scan_root_home(tmp.path());
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
@@ -34486,6 +35632,7 @@ mod tests {
     fn build_scan_roots_includes_remote_mirror_if_exists() {
         let _guard = ignore_sources_config();
         let tmp = TempDir::new().unwrap();
+        let _home_guard = isolate_scan_root_home(tmp.path());
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
@@ -34533,6 +35680,7 @@ mod tests {
     fn build_scan_roots_skips_nonexistent_mirror() {
         let _guard = ignore_sources_config();
         let tmp = TempDir::new().unwrap();
+        let _home_guard = isolate_scan_root_home(tmp.path());
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
@@ -34570,6 +35718,7 @@ mod tests {
     fn build_scan_roots_includes_configured_local_source_paths() {
         let _guard = ignore_sources_config();
         let tmp = TempDir::new().unwrap();
+        let _home_guard = isolate_scan_root_home(tmp.path());
         let data_dir = tmp.path().join("data");
         let backup_root = tmp.path().join("backup-root");
         std::fs::create_dir_all(&data_dir).unwrap();
@@ -34607,6 +35756,100 @@ mod tests {
         assert_eq!(backup_scan_root.path, backup_root);
         assert!(!backup_scan_root.origin.is_remote());
         assert_eq!(backup_scan_root.platform, Some(Platform::Linux));
+    }
+
+    #[test]
+    fn default_local_agent_scan_roots_include_aimux_and_opencode_locations() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let paths = [
+            home.join(".aimux/codex/codex-at/sessions"),
+            home.join(".aimux/claude/claude-at/projects"),
+            home.join(".aimux/claude/claude-at/.claude/projects"),
+            home.join(".aimux/gemini/julian.knutsen/.gemini/tmp/hash/chats"),
+            home.join(".aimux/opencode/team-a/storage"),
+            home.join(".local/share/opencode"),
+            home.join(".config/opencode"),
+            home.join(".opencode"),
+        ];
+        for path in paths {
+            std::fs::create_dir_all(path).unwrap();
+        }
+
+        let roots = default_local_agent_scan_roots_for_home(home);
+        let root_paths = roots
+            .iter()
+            .map(|root| root.path.clone())
+            .collect::<Vec<_>>();
+
+        for expected in [
+            home.join(".aimux/codex/codex-at/sessions"),
+            home.join(".aimux/claude/claude-at/projects"),
+            home.join(".aimux/claude/claude-at/.claude/projects"),
+            home.join(".aimux/gemini/julian.knutsen"),
+            home.join(".aimux/opencode/team-a"),
+            home.join(".local/share/opencode"),
+            home.join(".config/opencode"),
+            home.join(".opencode"),
+        ] {
+            assert!(
+                root_paths.contains(&expected),
+                "expected default scan root {} in {root_paths:?}",
+                expected.display()
+            );
+        }
+
+        let unique = root_paths.iter().collect::<std::collections::HashSet<_>>();
+        assert_eq!(unique.len(), root_paths.len());
+    }
+
+    #[test]
+    fn additional_scan_root_filter_uses_local_provider_hints() {
+        let tmp = TempDir::new().unwrap();
+        let mut codex_root = ScanRoot::local(tmp.path().join(".aimux/codex/codex-at/sessions"));
+        codex_root.origin.source_id = "aimux-codex".to_string();
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::Codex,
+            &codex_root
+        ));
+        assert!(!additional_scan_root_matches_kind(
+            ConnectorKind::OpenCode,
+            &codex_root
+        ));
+
+        let opencode_root = ScanRoot::local(tmp.path().join(".local/share/opencode"));
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::OpenCode,
+            &opencode_root
+        ));
+        assert!(!additional_scan_root_matches_kind(
+            ConnectorKind::Codex,
+            &opencode_root
+        ));
+
+        let generic_local_root = ScanRoot::local(tmp.path().join("backup-root"));
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::Codex,
+            &generic_local_root
+        ));
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::OpenCode,
+            &generic_local_root
+        ));
+
+        let remote_root = ScanRoot::remote(
+            tmp.path().join("remote-mirror"),
+            Origin::remote("builder-host"),
+            Some(Platform::Linux),
+        );
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::Codex,
+            &remote_root
+        ));
+        assert!(additional_scan_root_matches_kind(
+            ConnectorKind::OpenCode,
+            &remote_root
+        ));
     }
 
     #[test]
@@ -36195,8 +37438,11 @@ mod tests {
             &data_dir,
             &convs,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
         index.commit().unwrap();
@@ -36249,8 +37495,11 @@ mod tests {
             &data_dir,
             &convs,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
         index.commit().unwrap();
@@ -36310,8 +37559,11 @@ mod tests {
             &data_dir,
             &conv_a,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
         ingest_batch(
@@ -36320,8 +37572,11 @@ mod tests {
             &data_dir,
             &conv_b,
             &None,
-            LexicalPopulationStrategy::IncrementalInline,
-            false,
+            IngestBatchOptions {
+                lexical_strategy: LexicalPopulationStrategy::IncrementalInline,
+                defer_checkpoints: false,
+                insert_options: InsertConversationsOptions::from_env(),
+            },
         )
         .unwrap();
         drop(canonical_index);

--- a/src/indexer/redact_secrets.rs
+++ b/src/indexer/redact_secrets.rs
@@ -347,8 +347,8 @@ impl MemoizingRedactor {
 
     fn trace_audit(audit: &crate::indexer::memoization::MemoCacheAuditRecord) {
         // Severity tiers match operator expectations: hits are noise
-        // (trace), misses + inserts are routine (debug), evictions
-        // are noteworthy (info), invalidations and quarantines are
+        // (trace), misses, inserts, and bounded-cache evictions are
+        // routine (debug), while invalidations and quarantines are
         // alarming enough to warn so they show up in default-level
         // logs without dredging.
         use crate::indexer::memoization::MemoCacheEvent;
@@ -371,7 +371,7 @@ impl MemoizingRedactor {
                 live_entries = audit.stats.live_entries,
                 "redact memo insert"
             ),
-            MemoCacheEvent::Evict { ref reason } => tracing::info!(
+            MemoCacheEvent::Evict { ref reason } => tracing::debug!(
                 target: "cass::redact::memo",
                 evict_reason = ?reason,
                 live_entries = audit.stats.live_entries,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1785,6 +1785,38 @@ impl std::fmt::Display for AnalyticsBucketing {
     }
 }
 
+/// Analytics rebuild target.
+#[derive(Copy, Clone, Debug, Default, ValueEnum, PartialEq, Eq)]
+pub enum AnalyticsRebuildTrack {
+    /// Rebuild message_metrics and Track A rollups.
+    A,
+    /// Rebuild token_daily_stats from token_usage.
+    B,
+    /// Rebuild both analytics tracks.
+    #[default]
+    All,
+}
+
+impl AnalyticsRebuildTrack {
+    fn includes_track_a(self) -> bool {
+        matches!(self, Self::A | Self::All)
+    }
+
+    fn includes_track_b(self) -> bool {
+        matches!(self, Self::B | Self::All)
+    }
+}
+
+impl std::fmt::Display for AnalyticsRebuildTrack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::A => write!(f, "a"),
+            Self::B => write!(f, "b"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+
 /// Subcommands for analytics (token usage, tool, and model breakdowns).
 ///
 /// All subcommands share time-range, dimensional-filter, and output flags
@@ -1831,6 +1863,9 @@ pub enum AnalyticsCommand {
         /// Force full rebuild even if rollups appear fresh
         #[arg(long)]
         force: bool,
+        /// Analytics track to rebuild
+        #[arg(long, value_enum, default_value_t = AnalyticsRebuildTrack::All)]
+        track: AnalyticsRebuildTrack,
     },
     /// Check rollup invariants and detect drift between raw data and aggregates
     Validate {
@@ -9811,9 +9846,11 @@ fn run_analytics(cmd: AnalyticsCommand, db_path: Option<PathBuf>, cli: &Cli) -> 
         AnalyticsCommand::Tokens { common, group_by } => {
             run_analytics_tokens(common, *group_by, db_path.as_ref())?
         }
-        AnalyticsCommand::Rebuild { common, force } => {
-            run_analytics_rebuild(common, *force, db_path.as_ref())?
-        }
+        AnalyticsCommand::Rebuild {
+            common,
+            force,
+            track,
+        } => run_analytics_rebuild(common, *force, *track, db_path.as_ref())?,
         AnalyticsCommand::Tools {
             common,
             group_by,
@@ -10311,12 +10348,10 @@ fn run_analytics_tokens(
 // ---------------------------------------------------------------------------
 
 /// Run `cass analytics rebuild` — rebuild analytics rollup tables.
-///
-/// Currently rebuilds Track A (message_metrics + usage_hourly + usage_daily).
-/// Track B rebuild will be wired when z9fse.13 lands.
 fn run_analytics_rebuild(
     common: &AnalyticsCommon,
     _force: bool,
+    track: AnalyticsRebuildTrack,
     db_path_override: Option<&PathBuf>,
 ) -> CliResult<serde_json::Value> {
     use crate::storage::sqlite::FrankenStorage;
@@ -10339,9 +10374,6 @@ fn run_analytics_rebuild(
         });
     }
 
-    // Progress diagnostics go to stderr.
-    eprintln!("Rebuilding analytics (Track A)...");
-
     let storage = FrankenStorage::open(&db_path).map_err(|e| CliError {
         code: 9,
         kind: CliErrorKind::DbError.kind_str(),
@@ -10350,35 +10382,80 @@ fn run_analytics_rebuild(
         retryable: false,
     })?;
 
-    let result = storage.rebuild_analytics().map_err(|e| CliError {
-        code: 9,
-        kind: CliErrorKind::RebuildError.kind_str(),
-        message: format!("Analytics rebuild failed: {e}"),
-        hint: Some("Check database integrity with 'cass health --json'.".into()),
-        retryable: true,
-    })?;
+    let overall_start = Instant::now();
+    let mut tracks_rebuilt = Vec::new();
+    let mut track_a_json = serde_json::Value::Null;
+    let mut track_b_json = serde_json::Value::Null;
 
-    eprintln!(
-        "Rebuild complete: {} message_metrics, {} hourly, {} daily rows in {}ms ({:.0} msg/sec)",
-        result.message_metrics_rows,
-        result.usage_hourly_rows,
-        result.usage_daily_rows,
-        result.elapsed_ms,
-        result.messages_per_sec
-    );
+    if track.includes_track_a() {
+        eprintln!("Rebuilding analytics (Track A)...");
 
-    Ok(serde_json::json!({
-        "track": "a",
-        "tracks_rebuilt": ["a"],
-        "track_a": {
+        let result = storage.rebuild_analytics().map_err(|e| CliError {
+            code: 9,
+            kind: CliErrorKind::RebuildError.kind_str(),
+            message: format!("Track A analytics rebuild failed: {e}"),
+            hint: Some("Check database integrity with 'cass health --json'.".into()),
+            retryable: true,
+        })?;
+
+        eprintln!(
+            "Track A rebuild complete: {} message_metrics, {} hourly, {} daily rows in {}ms ({:.0} msg/sec)",
+            result.message_metrics_rows,
+            result.usage_hourly_rows,
+            result.usage_daily_rows,
+            result.elapsed_ms,
+            result.messages_per_sec
+        );
+
+        tracks_rebuilt.push("a");
+        track_a_json = serde_json::json!({
             "message_metrics_rows": result.message_metrics_rows,
             "usage_hourly_rows": result.usage_hourly_rows,
             "usage_daily_rows": result.usage_daily_rows,
             "usage_models_daily_rows": result.usage_models_daily_rows,
             "elapsed_ms": result.elapsed_ms,
             "rows_per_sec": result.messages_per_sec,
-        },
-        "overall_elapsed_ms": result.elapsed_ms,
+        });
+    }
+
+    if track.includes_track_b() {
+        eprintln!("Rebuilding analytics (Track B)...");
+
+        let track_b_start = Instant::now();
+        let token_daily_stats_rows = storage.rebuild_token_daily_stats().map_err(|e| CliError {
+            code: 9,
+            kind: CliErrorKind::RebuildError.kind_str(),
+            message: format!("Track B analytics rebuild failed: {e}"),
+            hint: Some("Check database integrity with 'cass health --json'.".into()),
+            retryable: true,
+        })?;
+        let track_b_elapsed_ms = track_b_start.elapsed().as_millis() as u64;
+        let rows_per_sec = if track_b_elapsed_ms > 0 {
+            (token_daily_stats_rows as f64) / (track_b_elapsed_ms as f64 / 1000.0)
+        } else {
+            0.0
+        };
+
+        eprintln!(
+            "Track B rebuild complete: {} token_daily_stats rows in {}ms ({:.0} rows/sec)",
+            token_daily_stats_rows, track_b_elapsed_ms, rows_per_sec
+        );
+
+        tracks_rebuilt.push("b");
+        track_b_json = serde_json::json!({
+            "token_daily_stats_rows": token_daily_stats_rows,
+            "elapsed_ms": track_b_elapsed_ms,
+            "rows_per_sec": rows_per_sec,
+        });
+    }
+
+    let overall_elapsed_ms = overall_start.elapsed().as_millis() as u64;
+    Ok(serde_json::json!({
+        "track": track.to_string(),
+        "tracks_rebuilt": tracks_rebuilt,
+        "track_a": track_a_json,
+        "track_b": track_b_json,
+        "overall_elapsed_ms": overall_elapsed_ms,
     }))
 }
 
@@ -13760,11 +13837,13 @@ fn render_analytics_docs() -> Vec<String> {
         "    (claude_code, codex, pi_agent, factory, opencode, cursor).".into(),
         String::new(),
         "### analytics rebuild".into(),
-        "  data.track: string ('a')".into(),
+        "  data.track: string ('a' | 'b' | 'all')".into(),
         "  data.tracks_rebuilt: [string]".into(),
         "  data.track_a: { message_metrics_rows, usage_hourly_rows, usage_daily_rows,".into(),
         "                  usage_models_daily_rows, elapsed_ms, rows_per_sec }".into(),
+        "  data.track_b: { token_daily_stats_rows, elapsed_ms, rows_per_sec }".into(),
         "  data.overall_elapsed_ms: u64".into(),
+        "  --track <a|b|all>: rebuild a single track or both tracks (default all)".into(),
         "  --force: rebuild even when rollups appear fresh".into(),
         String::new(),
         "### analytics validate".into(),
@@ -13795,7 +13874,7 @@ fn render_analytics_docs() -> Vec<String> {
         "  exit 9 + retryable=true: transient DB lock/busy — retry after 1s".into(),
         "  exit 9 + retryable=false: schema or data issue — run 'cass analytics rebuild' first".into(),
         "  exit 3: no database — run 'cass index --full' to create it".into(),
-        "  validate errors: use 'cass analytics validate --fix --json' for safe Track A repair, or 'cass analytics rebuild --force --json' for a manual rebuild loop".into(),
+        "  validate errors: use 'cass analytics validate --fix --json' for safe repair, or 'cass analytics rebuild --track all --force --json' for a manual rebuild loop".into(),
         String::new(),
         "## Common Workflows".into(),
         "  # Quick health check".into(),
@@ -13810,7 +13889,7 @@ fn render_analytics_docs() -> Vec<String> {
         "  # Validation + remediation loop".into(),
         "  cass analytics validate --json | jq '.data.summary'".into(),
         "  # If errors: rebuild then re-validate".into(),
-        "  cass analytics rebuild --force --json && cass analytics validate --json".into(),
+        "  cass analytics rebuild --track all --force --json && cass analytics validate --json".into(),
     ]
 }
 

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -2557,7 +2557,7 @@ fn is_backup_root_name(name: &str, prefix: &str) -> bool {
 }
 
 /// Public schema version constant for external checks.
-pub const CURRENT_SCHEMA_VERSION: i64 = 20;
+pub const CURRENT_SCHEMA_VERSION: i64 = 21;
 const MIN_IN_PLACE_MIGRATION_SCHEMA_VERSION: i64 = 13;
 
 /// Result of checking schema compatibility.
@@ -3179,6 +3179,15 @@ SELECT
 FROM conversations c
 LEFT JOIN conversation_tail_state ts ON ts.conversation_id = c.id
 WHERE c.external_id IS NOT NULL;
+";
+
+const MIGRATION_V21: &str = r"
+-- Speed replay de-duplication for incremental reprocessing. The merge path
+-- probes canonical messages by conversation_id plus created_at range to catch
+-- replay-equivalent messages whose idx shifted. Without this index that probe
+-- falls back to scanning the conversation's idx index.
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created
+    ON messages(conversation_id, created_at);
 ";
 
 /// Row from the embedding_jobs table.
@@ -3919,6 +3928,30 @@ impl FrankenStorage {
                     missing_tables.push(table_name);
                     continue;
                 }
+                if table_name == "token_daily_stats" && error_indicates_corrupt_derived_table(&err)
+                {
+                    tracing::warn!(
+                        target: "cass::analytics",
+                        error = %err,
+                        "repairing corrupt derived token_daily_stats table during database open"
+                    );
+                    let conn = rusqlite::Connection::open(&self.db_path).with_context(|| {
+                        format!(
+                            "opening sqlite db at {} to repair token_daily_stats",
+                            self.db_path.display()
+                        )
+                    })?;
+                    conn.execute_batch(
+                        "PRAGMA journal_mode = WAL;
+                         PRAGMA synchronous = NORMAL;
+                         PRAGMA busy_timeout = 30000;",
+                    )
+                    .with_context(|| "applying sqlite pragmas for token_daily_stats open repair")?;
+                    recreate_token_daily_stats_table(&conn).with_context(
+                        || "recreating corrupt derived token_daily_stats during database open",
+                    )?;
+                    continue;
+                }
                 return Err(err).with_context(|| {
                     format!("probing required schema table {table_name} for completeness")
                 });
@@ -4222,6 +4255,7 @@ fn build_cass_migrations_after_tail_cache() -> MigrationRunner {
         .add(18, "conversation_tail_state_hot_table", MIGRATION_V18)
         .add(19, "conversation_external_lookup", MIGRATION_V19)
         .add(20, "conversation_external_tail_lookup", MIGRATION_V20)
+        .add(21, "message_created_at_replay_lookup", MIGRATION_V21)
 }
 
 fn schema_migration_is_applied(conn: &FrankenConnection, version: i64) -> Result<bool> {
@@ -4399,6 +4433,9 @@ CREATE TABLE IF NOT EXISTS messages (
     extra_bin BLOB,
     UNIQUE(conversation_id, idx)
 );
+
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created
+    ON messages(conversation_id, created_at);
 
 CREATE TABLE IF NOT EXISTS snippets (
     id INTEGER PRIMARY KEY,
@@ -5070,7 +5107,7 @@ fn current_schema_repair_batches_for_missing_tables(
 }
 
 /// Migration name lookup for backfilling `_schema_migrations` during transition.
-const MIGRATION_NAMES: [(i64, &str); 20] = [
+const MIGRATION_NAMES: [(i64, &str); 21] = [
     (1, "core_tables"),
     (2, "fts_messages"),
     (3, "fts_messages_rebuild"),
@@ -5091,6 +5128,7 @@ const MIGRATION_NAMES: [(i64, &str); 20] = [
     (18, "conversation_tail_state_hot_table"),
     (19, "conversation_external_lookup"),
     (20, "conversation_external_tail_lookup"),
+    (21, "message_created_at_replay_lookup"),
 ];
 
 /// Transitions an existing database from `meta` table schema versioning to the
@@ -5238,6 +5276,14 @@ fn error_indicates_missing_table(err: &impl std::fmt::Display) -> bool {
     err.to_string()
         .to_ascii_lowercase()
         .contains("no such table")
+}
+
+fn error_indicates_corrupt_derived_table(err: &impl std::fmt::Display) -> bool {
+    let lower = err.to_string().to_ascii_lowercase();
+    lower.contains("database disk image is malformed")
+        || lower.contains("malformed")
+        || lower.contains("could not open storage cursor")
+        || lower.contains("root page")
 }
 
 fn error_indicates_missing_column(err: &impl std::fmt::Display) -> bool {
@@ -9974,12 +10020,23 @@ impl FrankenStorage {
         })
     }
 
-    /// Batch insert multiple conversations with full analytics (token usage,
-    /// message metrics, rollups).  Frankensqlite equivalent of
-    /// `SqliteStorage::insert_conversations_batched`.
+    /// Batch insert multiple conversations with full derived updates by default.
+    ///
+    /// Frankensqlite equivalent of `SqliteStorage::insert_conversations_batched`.
     pub fn insert_conversations_batched(
         &self,
         conversations: &[(i64, Option<i64>, &Conversation)],
+    ) -> Result<Vec<InsertOutcome>> {
+        self.insert_conversations_batched_with_options(
+            conversations,
+            InsertConversationsOptions::from_env(),
+        )
+    }
+
+    pub(crate) fn insert_conversations_batched_with_options(
+        &self,
+        conversations: &[(i64, Option<i64>, &Conversation)],
+        options: InsertConversationsOptions,
     ) -> Result<Vec<InsertOutcome>> {
         if conversations.is_empty() {
             return Ok(Vec::new());
@@ -9987,8 +10044,8 @@ impl FrankenStorage {
 
         self.ensure_sources_for_batch(conversations)?;
 
-        let defer_lexical_updates = defer_storage_lexical_updates_enabled();
-        let defer_analytics_updates = defer_analytics_updates_enabled();
+        let defer_lexical_updates = options.defer_lexical_updates;
+        let defer_analytics_updates = options.defer_analytics_updates;
 
         let pricing_table = PricingTable::franken_load(&self.conn).unwrap_or_else(|e| {
             tracing::warn!(target: "cass::analytics::pricing", error = %e, "failed to load pricing table");
@@ -10512,18 +10569,8 @@ impl FrankenStorage {
             );
         }
 
-        // Batched token_daily_stats update
-        if !defer_analytics_updates && !token_stats.is_empty() {
-            let entries = token_stats.expand();
-            let affected = franken_update_token_daily_stats_batched_in_tx(&tx, &entries)?;
-            tracing::debug!(
-                target: "cass::perf::token_daily_stats",
-                raw = token_stats.raw_entry_count(),
-                expanded = entries.len(),
-                affected = affected,
-                "franken_batched_token_stats_update_complete"
-            );
-        }
+        let rebuild_token_daily_stats_after_commit =
+            !defer_analytics_updates && !token_stats.is_empty();
 
         // Batch insert message_metrics rows
         if !defer_analytics_updates && !metrics_entries.is_empty() {
@@ -10561,6 +10608,17 @@ impl FrankenStorage {
         }
 
         tx.commit()?;
+
+        if rebuild_token_daily_stats_after_commit {
+            let rows = self
+                .rebuild_token_daily_stats()
+                .with_context(|| "rebuilding token_daily_stats after token_usage commit")?;
+            tracing::debug!(
+                target: "cass::perf::token_daily_stats",
+                rows,
+                "token_daily_stats_post_commit_rebuild_complete"
+            );
+        }
 
         pricing_diag.log_summary();
 
@@ -10824,6 +10882,28 @@ fn defer_storage_lexical_updates_enabled() -> bool {
 
 fn defer_analytics_updates_enabled() -> bool {
     env_flag_enabled("CASS_DEFER_ANALYTICS_UPDATES")
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InsertConversationsOptions {
+    pub(crate) defer_lexical_updates: bool,
+    pub(crate) defer_analytics_updates: bool,
+}
+
+impl InsertConversationsOptions {
+    pub(crate) fn from_env() -> Self {
+        Self {
+            defer_lexical_updates: defer_storage_lexical_updates_enabled(),
+            defer_analytics_updates: defer_analytics_updates_enabled(),
+        }
+    }
+
+    pub(crate) fn defer_derived_updates() -> Self {
+        Self {
+            defer_lexical_updates: true,
+            defer_analytics_updates: true,
+        }
+    }
 }
 
 enum ConversationInsertStatus {
@@ -11835,7 +11915,7 @@ fn franken_existing_message_lookup(
         )?;
         rows.extend(tx.query_params(
             "SELECT idx, role, author, created_at, content
-             FROM messages INDEXED BY sqlite_autoindex_messages_1
+             FROM messages INDEXED BY idx_messages_conv_created
              WHERE conversation_id = ?1
                AND created_at IS NOT NULL
                AND created_at >= ?2
@@ -12289,77 +12369,54 @@ fn franken_insert_token_usage_batched_in_tx(
     Ok(total_inserted)
 }
 
-/// Batch upsert token_daily_stats within a frankensqlite transaction.
-fn franken_update_token_daily_stats_batched_in_tx(
-    tx: &FrankenTransaction<'_>,
-    entries: &[(i64, String, String, String, TokenStatsDelta)],
-) -> Result<usize> {
-    if entries.is_empty() {
-        return Ok(0);
-    }
-
-    let now = FrankenStorage::now_millis();
-    let mut total_affected = 0;
-
-    for (day_id, agent, source, model, delta) in entries {
-        total_affected += tx.execute_compat(
-            "INSERT INTO token_daily_stats (
-                day_id, agent_slug, source_id, model_family,
-                api_call_count, user_message_count, assistant_message_count, tool_message_count,
-                total_input_tokens, total_output_tokens, total_cache_read_tokens,
-                total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
-                total_content_chars, total_tool_calls, estimated_cost_usd, session_count,
-                last_updated
-            )
-            VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)
-            ON CONFLICT(day_id, agent_slug, source_id, model_family) DO UPDATE SET
-                api_call_count = api_call_count + excluded.api_call_count,
-                user_message_count = user_message_count + excluded.user_message_count,
-                assistant_message_count = assistant_message_count + excluded.assistant_message_count,
-                tool_message_count = tool_message_count + excluded.tool_message_count,
-                total_input_tokens = total_input_tokens + excluded.total_input_tokens,
-                total_output_tokens = total_output_tokens + excluded.total_output_tokens,
-                total_cache_read_tokens = total_cache_read_tokens + excluded.total_cache_read_tokens,
-                total_cache_creation_tokens = total_cache_creation_tokens + excluded.total_cache_creation_tokens,
-                total_thinking_tokens = total_thinking_tokens + excluded.total_thinking_tokens,
-                grand_total_tokens = grand_total_tokens + excluded.grand_total_tokens,
-                total_content_chars = total_content_chars + excluded.total_content_chars,
-                total_tool_calls = total_tool_calls + excluded.total_tool_calls,
-                estimated_cost_usd = estimated_cost_usd + excluded.estimated_cost_usd,
-                session_count = session_count + excluded.session_count,
-                last_updated = excluded.last_updated",
-            fparams![
-                *day_id,
-                agent.as_str(),
-                source.as_str(),
-                model.as_str(),
-                delta.api_call_count,
-                delta.user_message_count,
-                delta.assistant_message_count,
-                delta.tool_message_count,
-                delta.total_input_tokens,
-                delta.total_output_tokens,
-                delta.total_cache_read_tokens,
-                delta.total_cache_creation_tokens,
-                delta.total_thinking_tokens,
-                delta.grand_total_tokens,
-                delta.total_content_chars,
-                delta.total_tool_calls,
-                delta.estimated_cost_usd,
-                delta.session_count,
-                now
-            ],
-        )?;
-    }
-
-    Ok(total_affected)
-}
-
 /// Batch insert message_metrics rows within a frankensqlite transaction.
 ///
 /// Uses row-wise INSERT OR IGNORE to avoid the frankensqlite limitation where
 /// multi-row VALUES lists fall through to INSERT...SELECT, which rejects
 /// UPSERT/OR IGNORE conflict clauses.
+const MESSAGE_METRICS_INSERT_SQL: &str = "\
+INSERT OR IGNORE INTO message_metrics (
+    message_id, created_at_ms, hour_id, day_id,
+    agent_slug, workspace_id, source_id, role,
+    content_chars, content_tokens_est,
+    model_name, model_family, model_tier, provider,
+    api_input_tokens, api_output_tokens, api_cache_read_tokens,
+    api_cache_creation_tokens, api_thinking_tokens,
+    api_service_tier, api_data_source,
+    tool_call_count, has_tool_calls, has_plan
+)
+VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24)";
+
+fn message_metrics_param_values(e: &MessageMetricsEntry) -> Vec<SqliteValue> {
+    let params_vec: Vec<ParamValue> = vec![
+        ParamValue::from(e.message_id),
+        ParamValue::from(e.created_at_ms),
+        ParamValue::from(e.hour_id),
+        ParamValue::from(e.day_id),
+        ParamValue::from(e.agent_slug.clone()),
+        ParamValue::from(e.workspace_id),
+        ParamValue::from(e.source_id.clone()),
+        ParamValue::from(e.role.clone()),
+        ParamValue::from(e.content_chars),
+        ParamValue::from(e.content_tokens_est),
+        ParamValue::from(e.model_name.clone()),
+        ParamValue::from(e.model_family.clone()),
+        ParamValue::from(e.model_tier.clone()),
+        ParamValue::from(e.provider.clone()),
+        ParamValue::from(e.api_input_tokens),
+        ParamValue::from(e.api_output_tokens),
+        ParamValue::from(e.api_cache_read_tokens),
+        ParamValue::from(e.api_cache_creation_tokens),
+        ParamValue::from(e.api_thinking_tokens),
+        ParamValue::from(e.api_service_tier.clone()),
+        ParamValue::from(e.api_data_source.clone()),
+        ParamValue::from(e.tool_call_count),
+        ParamValue::from(e.has_tool_calls as i64),
+        ParamValue::from(e.has_plan as i64),
+    ];
+    param_slice_to_values(&params_vec)
+}
+
 fn franken_insert_message_metrics_batched_in_tx(
     tx: &FrankenTransaction<'_>,
     entries: &[MessageMetricsEntry],
@@ -12371,48 +12428,8 @@ fn franken_insert_message_metrics_batched_in_tx(
     let mut total_inserted = 0;
 
     for e in entries {
-        let params_vec: Vec<ParamValue> = vec![
-            ParamValue::from(e.message_id),
-            ParamValue::from(e.created_at_ms),
-            ParamValue::from(e.hour_id),
-            ParamValue::from(e.day_id),
-            ParamValue::from(e.agent_slug.clone()),
-            ParamValue::from(e.workspace_id),
-            ParamValue::from(e.source_id.clone()),
-            ParamValue::from(e.role.clone()),
-            ParamValue::from(e.content_chars),
-            ParamValue::from(e.content_tokens_est),
-            ParamValue::from(e.model_name.clone()),
-            ParamValue::from(e.model_family.clone()),
-            ParamValue::from(e.model_tier.clone()),
-            ParamValue::from(e.provider.clone()),
-            ParamValue::from(e.api_input_tokens),
-            ParamValue::from(e.api_output_tokens),
-            ParamValue::from(e.api_cache_read_tokens),
-            ParamValue::from(e.api_cache_creation_tokens),
-            ParamValue::from(e.api_thinking_tokens),
-            ParamValue::from(e.api_service_tier.clone()),
-            ParamValue::from(e.api_data_source.clone()),
-            ParamValue::from(e.tool_call_count),
-            ParamValue::from(e.has_tool_calls as i64),
-            ParamValue::from(e.has_plan as i64),
-        ];
-
-        let values = param_slice_to_values(&params_vec);
-        total_inserted += tx.execute_with_params(
-            "INSERT OR IGNORE INTO message_metrics (
-                message_id, created_at_ms, hour_id, day_id,
-                agent_slug, workspace_id, source_id, role,
-                content_chars, content_tokens_est,
-                model_name, model_family, model_tier, provider,
-                api_input_tokens, api_output_tokens, api_cache_read_tokens,
-                api_cache_creation_tokens, api_thinking_tokens,
-                api_service_tier, api_data_source,
-                tool_call_count, has_tool_calls, has_plan
-            )
-            VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24)",
-            &values,
-        )?;
+        total_inserted +=
+            tx.execute_with_params(MESSAGE_METRICS_INSERT_SQL, &message_metrics_param_values(e))?;
     }
 
     Ok(total_inserted)
@@ -12613,159 +12630,468 @@ fn franken_update_conversation_token_summaries_in_tx(
     Ok(())
 }
 
+const ANALYTICS_REBUILD_MESSAGE_METRICS_BULK_SQL: &str = "\
+INSERT OR REPLACE INTO message_metrics (
+    message_id, created_at_ms, hour_id, day_id,
+    agent_slug, workspace_id, source_id, role,
+    content_chars, content_tokens_est,
+    model_name, model_family, model_tier, provider,
+    api_input_tokens, api_output_tokens, api_cache_read_tokens,
+    api_cache_creation_tokens, api_thinking_tokens,
+    api_service_tier, api_data_source,
+    tool_call_count, has_tool_calls, has_plan
+)
+SELECT
+    id,
+    ts,
+    CAST(((ts / 1000) - 1577836800) / 3600 AS INTEGER),
+    CAST(((ts / 1000) - 1577836800) / 86400 AS INTEGER),
+    agent_slug,
+    workspace_id,
+    source_id,
+    role,
+    content_chars,
+    content_chars / 4,
+    model_name,
+    COALESCE(model_family, 'unknown'),
+    COALESCE(model_tier, 'unknown'),
+    COALESCE(provider, 'unknown'),
+    CASE
+        WHEN input_tokens IS NOT NULL THEN input_tokens
+        WHEN data_source = 'api' AND role = 'user' THEN total_tokens
+        ELSE NULL
+    END,
+    CASE
+        WHEN output_tokens IS NOT NULL THEN output_tokens
+        WHEN data_source = 'api' AND role != 'user' THEN total_tokens
+        ELSE NULL
+    END,
+    cache_read_tokens,
+    cache_creation_tokens,
+    thinking_tokens,
+    service_tier,
+    COALESCE(data_source, 'estimated'),
+    COALESCE(tool_call_count, 0),
+    COALESCE(has_tool_calls, 0),
+    CASE
+        WHEN role IN ('assistant', 'agent')
+         AND content_lc LIKE '%plan%'
+         AND (content_lc LIKE '%step%' OR content_lc LIKE '%1.%' OR content_lc LIKE '%- %')
+        THEN 1 ELSE 0
+    END
+FROM (
+    SELECT
+        m.id AS id,
+        COALESCE(m.created_at, c.started_at, 0) AS ts,
+        COALESCE(a.slug, 'unknown') AS agent_slug,
+        COALESCE(c.workspace_id, 0) AS workspace_id,
+        c.source_id AS source_id,
+        m.role AS role,
+        COALESCE(LENGTH(CAST(m.content AS BLOB)), 0) AS content_chars,
+        LOWER(COALESCE(m.content, '')) AS content_lc,
+        tu.model_name AS model_name,
+        tu.model_family AS model_family,
+        tu.model_tier AS model_tier,
+        tu.provider AS provider,
+        tu.input_tokens AS input_tokens,
+        tu.output_tokens AS output_tokens,
+        tu.cache_read_tokens AS cache_read_tokens,
+        tu.cache_creation_tokens AS cache_creation_tokens,
+        tu.thinking_tokens AS thinking_tokens,
+        tu.total_tokens AS total_tokens,
+        tu.service_tier AS service_tier,
+        tu.data_source AS data_source,
+        tu.tool_call_count AS tool_call_count,
+        tu.has_tool_calls AS has_tool_calls
+    FROM messages m
+    JOIN conversations c ON m.conversation_id = c.id
+    LEFT JOIN agents a ON a.id = c.agent_id
+    LEFT JOIN token_usage tu ON tu.message_id = m.id
+)";
+
+const ANALYTICS_REBUILD_USAGE_HOURLY_BULK_SQL: &str = "\
+INSERT INTO usage_hourly (
+    hour_id, agent_slug, workspace_id, source_id,
+    message_count, user_message_count, assistant_message_count,
+    tool_call_count, plan_message_count, api_coverage_message_count,
+    content_tokens_est_total, content_tokens_est_user, content_tokens_est_assistant,
+    api_tokens_total, api_input_tokens_total, api_output_tokens_total,
+    api_cache_read_tokens_total, api_cache_creation_tokens_total,
+    api_thinking_tokens_total, last_updated,
+    plan_content_tokens_est_total, plan_api_tokens_total
+)
+SELECT
+    hour_id, agent_slug, workspace_id, source_id,
+    COUNT(*),
+    SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN 1 ELSE 0 END),
+    SUM(tool_call_count),
+    SUM(has_plan),
+    SUM(CASE WHEN api_data_source = 'api' THEN 1 ELSE 0 END),
+    SUM(content_tokens_est),
+    SUM(CASE WHEN role = 'user' THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) + COALESCE(api_output_tokens, 0) + COALESCE(api_cache_read_tokens, 0) + COALESCE(api_cache_creation_tokens, 0) + COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_output_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_read_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_creation_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    ?1,
+    SUM(CASE WHEN has_plan != 0 THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN has_plan != 0 AND api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) + COALESCE(api_output_tokens, 0) + COALESCE(api_cache_read_tokens, 0) + COALESCE(api_cache_creation_tokens, 0) + COALESCE(api_thinking_tokens, 0) ELSE 0 END)
+FROM message_metrics
+GROUP BY hour_id, agent_slug, workspace_id, source_id";
+
+const ANALYTICS_REBUILD_USAGE_DAILY_BULK_SQL: &str = "\
+INSERT INTO usage_daily (
+    day_id, agent_slug, workspace_id, source_id,
+    message_count, user_message_count, assistant_message_count,
+    tool_call_count, plan_message_count, api_coverage_message_count,
+    content_tokens_est_total, content_tokens_est_user, content_tokens_est_assistant,
+    api_tokens_total, api_input_tokens_total, api_output_tokens_total,
+    api_cache_read_tokens_total, api_cache_creation_tokens_total,
+    api_thinking_tokens_total, last_updated,
+    plan_content_tokens_est_total, plan_api_tokens_total
+)
+SELECT
+    day_id, agent_slug, workspace_id, source_id,
+    COUNT(*),
+    SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN 1 ELSE 0 END),
+    SUM(tool_call_count),
+    SUM(has_plan),
+    SUM(CASE WHEN api_data_source = 'api' THEN 1 ELSE 0 END),
+    SUM(content_tokens_est),
+    SUM(CASE WHEN role = 'user' THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) + COALESCE(api_output_tokens, 0) + COALESCE(api_cache_read_tokens, 0) + COALESCE(api_cache_creation_tokens, 0) + COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_output_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_read_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_creation_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    ?1,
+    SUM(CASE WHEN has_plan != 0 THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN has_plan != 0 AND api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) + COALESCE(api_output_tokens, 0) + COALESCE(api_cache_read_tokens, 0) + COALESCE(api_cache_creation_tokens, 0) + COALESCE(api_thinking_tokens, 0) ELSE 0 END)
+FROM message_metrics
+GROUP BY day_id, agent_slug, workspace_id, source_id";
+
+const ANALYTICS_REBUILD_USAGE_MODELS_DAILY_BULK_SQL: &str = "\
+INSERT INTO usage_models_daily (
+    day_id, agent_slug, workspace_id, source_id, model_family, model_tier,
+    message_count, user_message_count, assistant_message_count,
+    tool_call_count, plan_message_count, api_coverage_message_count,
+    content_tokens_est_total, content_tokens_est_user, content_tokens_est_assistant,
+    api_tokens_total, api_input_tokens_total, api_output_tokens_total,
+    api_cache_read_tokens_total, api_cache_creation_tokens_total,
+    api_thinking_tokens_total, last_updated
+)
+SELECT
+    day_id, agent_slug, workspace_id, source_id, model_family, model_tier,
+    COUNT(*),
+    SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN 1 ELSE 0 END),
+    SUM(tool_call_count),
+    SUM(has_plan),
+    SUM(CASE WHEN api_data_source = 'api' THEN 1 ELSE 0 END),
+    SUM(content_tokens_est),
+    SUM(CASE WHEN role = 'user' THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN role IN ('assistant', 'agent') THEN content_tokens_est ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) + COALESCE(api_output_tokens, 0) + COALESCE(api_cache_read_tokens, 0) + COALESCE(api_cache_creation_tokens, 0) + COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_input_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_output_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_read_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_cache_creation_tokens, 0) ELSE 0 END),
+    SUM(CASE WHEN api_data_source = 'api' THEN COALESCE(api_thinking_tokens, 0) ELSE 0 END),
+    ?1
+FROM message_metrics
+GROUP BY day_id, agent_slug, workspace_id, source_id, model_family, model_tier";
+
+const TOKEN_DAILY_STATS_REBUILD_BULK_SQL: &str = "\
+WITH token_raw AS (
+    SELECT
+        tu.day_id AS day_id,
+        COALESCE(a.slug, 'unknown') AS agent_slug,
+        COALESCE(c.source_id, 'local') AS source_id,
+        COALESCE(tu.model_family, 'unknown') AS model_family,
+        COUNT(*) AS api_call_count,
+        SUM(CASE WHEN tu.role = 'user' THEN 1 ELSE 0 END) AS user_message_count,
+        SUM(CASE WHEN tu.role IN ('assistant', 'agent') THEN 1 ELSE 0 END) AS assistant_message_count,
+        SUM(CASE WHEN tu.role = 'tool' THEN 1 ELSE 0 END) AS tool_message_count,
+        SUM(COALESCE(tu.input_tokens, 0)) AS total_input_tokens,
+        SUM(COALESCE(tu.output_tokens, 0)) AS total_output_tokens,
+        SUM(COALESCE(tu.cache_read_tokens, 0)) AS total_cache_read_tokens,
+        SUM(COALESCE(tu.cache_creation_tokens, 0)) AS total_cache_creation_tokens,
+        SUM(COALESCE(tu.thinking_tokens, 0)) AS total_thinking_tokens,
+        SUM(COALESCE(
+            tu.total_tokens,
+            COALESCE(tu.input_tokens, 0) +
+            COALESCE(tu.output_tokens, 0) +
+            COALESCE(tu.cache_read_tokens, 0) +
+            COALESCE(tu.cache_creation_tokens, 0) +
+            COALESCE(tu.thinking_tokens, 0)
+        )) AS grand_total_tokens,
+        SUM(COALESCE(tu.content_chars, 0)) AS total_content_chars,
+        SUM(COALESCE(tu.tool_call_count, 0)) AS total_tool_calls,
+        SUM(COALESCE(tu.estimated_cost_usd, 0.0)) AS estimated_cost_usd,
+        0 AS session_count
+    FROM token_usage tu
+    LEFT JOIN conversations c ON c.id = tu.conversation_id
+    LEFT JOIN agents a ON a.id = c.agent_id
+    GROUP BY
+        tu.day_id,
+        COALESCE(a.slug, 'unknown'),
+        COALESCE(c.source_id, 'local'),
+        COALESCE(tu.model_family, 'unknown')
+),
+session_raw AS (
+    SELECT
+        CAST(((COALESCE(c.started_at, 0) / 1000) - 1577836800) / 86400 AS INTEGER) AS day_id,
+        COALESCE(a.slug, 'unknown') AS agent_slug,
+        COALESCE(c.source_id, 'local') AS source_id,
+        COALESCE((
+            SELECT COALESCE(tu2.model_family, 'unknown')
+            FROM token_usage tu2
+            WHERE tu2.conversation_id = c.id
+              AND COALESCE(tu2.model_family, 'unknown') != 'unknown'
+            ORDER BY tu2.id DESC
+            LIMIT 1
+        ), 'unknown') AS model_family,
+        0 AS api_call_count,
+        0 AS user_message_count,
+        0 AS assistant_message_count,
+        0 AS tool_message_count,
+        0 AS total_input_tokens,
+        0 AS total_output_tokens,
+        0 AS total_cache_read_tokens,
+        0 AS total_cache_creation_tokens,
+        0 AS total_thinking_tokens,
+        0 AS grand_total_tokens,
+        0 AS total_content_chars,
+        0 AS total_tool_calls,
+        0.0 AS estimated_cost_usd,
+        COUNT(*) AS session_count
+    FROM conversations c
+    LEFT JOIN agents a ON a.id = c.agent_id
+    GROUP BY
+        CAST(((COALESCE(c.started_at, 0) / 1000) - 1577836800) / 86400 AS INTEGER),
+        COALESCE(a.slug, 'unknown'),
+        COALESCE(c.source_id, 'local'),
+        model_family
+),
+raw AS (
+    SELECT * FROM token_raw
+    UNION ALL
+    SELECT * FROM session_raw
+),
+expanded AS (
+    SELECT * FROM raw
+    UNION ALL
+    SELECT day_id, 'all', source_id, model_family,
+           api_call_count, user_message_count, assistant_message_count, tool_message_count,
+           total_input_tokens, total_output_tokens, total_cache_read_tokens,
+           total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
+           total_content_chars, total_tool_calls, estimated_cost_usd, session_count
+    FROM raw
+    WHERE agent_slug != 'all'
+    UNION ALL
+    SELECT day_id, agent_slug, 'all', model_family,
+           api_call_count, user_message_count, assistant_message_count, tool_message_count,
+           total_input_tokens, total_output_tokens, total_cache_read_tokens,
+           total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
+           total_content_chars, total_tool_calls, estimated_cost_usd, session_count
+    FROM raw
+    WHERE source_id != 'all'
+    UNION ALL
+    SELECT day_id, agent_slug, source_id, 'all',
+           api_call_count, user_message_count, assistant_message_count, tool_message_count,
+           total_input_tokens, total_output_tokens, total_cache_read_tokens,
+           total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
+           total_content_chars, total_tool_calls, estimated_cost_usd, session_count
+    FROM raw
+    WHERE model_family != 'all'
+    UNION ALL
+    SELECT day_id, 'all', 'all', 'all',
+           api_call_count, user_message_count, assistant_message_count, tool_message_count,
+           total_input_tokens, total_output_tokens, total_cache_read_tokens,
+           total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
+           total_content_chars, total_tool_calls, estimated_cost_usd, session_count
+    FROM raw
+    WHERE NOT (agent_slug = 'all' AND source_id = 'all' AND model_family = 'all')
+)
+INSERT INTO token_daily_stats (
+    day_id, agent_slug, source_id, model_family,
+    api_call_count, user_message_count, assistant_message_count, tool_message_count,
+    total_input_tokens, total_output_tokens, total_cache_read_tokens,
+    total_cache_creation_tokens, total_thinking_tokens, grand_total_tokens,
+    total_content_chars, total_tool_calls, estimated_cost_usd, session_count,
+    last_updated
+)
+SELECT
+    day_id, agent_slug, source_id, model_family,
+    SUM(api_call_count),
+    SUM(user_message_count),
+    SUM(assistant_message_count),
+    SUM(tool_message_count),
+    SUM(total_input_tokens),
+    SUM(total_output_tokens),
+    SUM(total_cache_read_tokens),
+    SUM(total_cache_creation_tokens),
+    SUM(total_thinking_tokens),
+    SUM(grand_total_tokens),
+    SUM(total_content_chars),
+    SUM(total_tool_calls),
+    SUM(estimated_cost_usd),
+    SUM(session_count),
+    ?1
+FROM expanded
+GROUP BY day_id, agent_slug, source_id, model_family";
+
+const TOKEN_DAILY_STATS_CREATE_SQL: &str = "\
+CREATE TABLE token_daily_stats (
+    day_id INTEGER NOT NULL,
+    agent_slug TEXT NOT NULL,
+    source_id TEXT NOT NULL DEFAULT 'all',
+    model_family TEXT NOT NULL DEFAULT 'all',
+
+    api_call_count INTEGER NOT NULL DEFAULT 0,
+    user_message_count INTEGER NOT NULL DEFAULT 0,
+    assistant_message_count INTEGER NOT NULL DEFAULT 0,
+    tool_message_count INTEGER NOT NULL DEFAULT 0,
+
+    total_input_tokens INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    total_thinking_tokens INTEGER NOT NULL DEFAULT 0,
+    grand_total_tokens INTEGER NOT NULL DEFAULT 0,
+
+    total_content_chars INTEGER NOT NULL DEFAULT 0,
+    total_tool_calls INTEGER NOT NULL DEFAULT 0,
+
+    estimated_cost_usd REAL NOT NULL DEFAULT 0.0,
+
+    session_count INTEGER NOT NULL DEFAULT 0,
+
+    last_updated INTEGER NOT NULL,
+
+    PRIMARY KEY (day_id, agent_slug, source_id, model_family)
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_daily_stats_agent
+    ON token_daily_stats(agent_slug, day_id);
+CREATE INDEX IF NOT EXISTS idx_token_daily_stats_model
+    ON token_daily_stats(model_family, day_id);";
+
+fn recreate_token_daily_stats_table(conn: &rusqlite::Connection) -> Result<()> {
+    match conn.execute_batch("DROP TABLE IF EXISTS token_daily_stats;") {
+        Ok(()) => {}
+        Err(drop_err) => {
+            tracing::warn!(
+                target: "cass::analytics",
+                error = %drop_err,
+                "token_daily_stats drop failed; abandoning derived table schema"
+            );
+            abandon_token_daily_stats_schema(conn).with_context(|| {
+                format!("abandoning malformed token_daily_stats after drop failed: {drop_err}")
+            })?;
+        }
+    }
+
+    conn.execute_batch(TOKEN_DAILY_STATS_CREATE_SQL)
+        .with_context(|| "creating token_daily_stats")?;
+    Ok(())
+}
+
+fn abandon_token_daily_stats_schema(conn: &rusqlite::Connection) -> Result<()> {
+    let schema_version: i64 = conn
+        .query_row("PRAGMA schema_version;", [], |row| row.get(0))
+        .unwrap_or(0);
+
+    conn.execute_batch("PRAGMA writable_schema = ON;")
+        .with_context(|| "enabling writable_schema for token_daily_stats repair")?;
+    let delete_result = conn.execute(
+        "DELETE FROM sqlite_schema
+         WHERE tbl_name = 'token_daily_stats'
+            OR name IN (
+                'token_daily_stats',
+                'idx_token_daily_stats_agent',
+                'idx_token_daily_stats_model',
+                'sqlite_autoindex_token_daily_stats_1'
+            )",
+        [],
+    );
+    let disable_result = conn.execute_batch("PRAGMA writable_schema = OFF;");
+
+    let deleted = match delete_result {
+        Ok(deleted) => deleted,
+        Err(err) => {
+            let _ = disable_result;
+            return Err(anyhow!(
+                "deleting malformed token_daily_stats schema entries: {err}"
+            ));
+        }
+    };
+    disable_result.with_context(|| "disabling writable_schema after token_daily_stats repair")?;
+
+    let next_schema_version = schema_version.saturating_add(1);
+    conn.execute_batch(&format!("PRAGMA schema_version = {next_schema_version};"))
+        .with_context(|| "bumping schema_version after token_daily_stats repair")?;
+    tracing::warn!(
+        target: "cass::analytics",
+        deleted,
+        "abandoned malformed token_daily_stats schema entries"
+    );
+    Ok(())
+}
+
 impl FrankenStorage {
     /// Rebuild token_daily_stats from the token_usage ledger.
     pub fn rebuild_token_daily_stats(&self) -> Result<usize> {
-        const CONVERSATION_BATCH_SIZE: usize = 1_000;
-        const TOKEN_USAGE_BATCH_SIZE: usize = 10_000;
+        let mut conn = rusqlite::Connection::open(&self.db_path)
+            .with_context(|| format!("opening sqlite db at {}", self.db_path.display()))?;
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA cache_size = -65536;
+             PRAGMA foreign_keys = ON;
+             PRAGMA busy_timeout = 30000;",
+        )
+        .with_context(|| {
+            format!(
+                "applying sqlite token stats rebuild pragmas for {}",
+                self.db_path.display()
+            )
+        })?;
 
-        let total_usage_rows: i64 =
-            self.conn
-                .query_row_map("SELECT COUNT(*) FROM token_usage", fparams![], |row| {
-                    row.get_typed(0)
-                })?;
+        let total_usage_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM token_usage", [], |row| row.get(0))
+            .with_context(|| "counting token_usage before token_daily_stats rebuild")?;
         tracing::info!(
             target: "cass::analytics",
             total_usage_rows,
             "token_daily_stats_rebuild_start"
         );
 
-        let mut tx = self.conn.transaction()?;
-        tx.execute("DELETE FROM token_daily_stats")?;
+        recreate_token_daily_stats_table(&conn)
+            .with_context(|| "recreating token_daily_stats before rebuild")?;
 
-        let mut last_conversation_id = 0_i64;
-        let mut rows_created = 0_usize;
-
-        loop {
-            let conversation_rows = tx.query_map_collect(
-                "SELECT c.id, c.started_at, c.source_id,
-                        COALESCE((SELECT a.slug FROM agents a WHERE a.id = c.agent_id), 'unknown')
-                 FROM conversations c
-                 WHERE c.id > ?1
-                 ORDER BY c.id
-                 LIMIT ?2",
-                fparams![last_conversation_id, CONVERSATION_BATCH_SIZE as i64],
-                |row| {
-                    Ok((
-                        row.get_typed::<i64>(0)?,
-                        row.get_typed::<Option<i64>>(1)?,
-                        row.get_typed::<String>(2)?,
-                        row.get_typed::<String>(3)?,
-                    ))
-                },
-            )?;
-            if conversation_rows.is_empty() {
-                break;
-            }
-
-            let mut aggregate = TokenStatsAggregator::new();
-
-            for (conversation_id, started_at, source_id, agent_slug) in conversation_rows {
-                last_conversation_id = conversation_id;
-                let conversation_day_id = started_at.map(Self::day_id_from_millis).unwrap_or(0);
-                let mut last_token_usage_id = 0_i64;
-                let mut session_model_family = String::from("unknown");
-
-                loop {
-                    let usage_rows = tx.query_map_collect(
-                        "SELECT id, day_id, role,
-                                COALESCE(model_family, 'unknown'),
-                                input_tokens, output_tokens, cache_read_tokens,
-                                cache_creation_tokens, thinking_tokens,
-                                has_tool_calls, tool_call_count,
-                                content_chars, estimated_cost_usd
-                         FROM token_usage
-                         WHERE conversation_id = ?1
-                           AND id > ?2
-                         ORDER BY id
-                         LIMIT ?3",
-                        fparams![
-                            conversation_id,
-                            last_token_usage_id,
-                            TOKEN_USAGE_BATCH_SIZE as i64
-                        ],
-                        |row| {
-                            Ok((
-                                row.get_typed::<i64>(0)?,
-                                row.get_typed::<i64>(1)?,
-                                row.get_typed::<String>(2)?,
-                                row.get_typed::<String>(3)?,
-                                row.get_typed::<Option<i64>>(4)?,
-                                row.get_typed::<Option<i64>>(5)?,
-                                row.get_typed::<Option<i64>>(6)?,
-                                row.get_typed::<Option<i64>>(7)?,
-                                row.get_typed::<Option<i64>>(8)?,
-                                row.get_typed::<i64>(9)?,
-                                row.get_typed::<i64>(10)?,
-                                row.get_typed::<i64>(11)?,
-                                row.get_typed::<Option<f64>>(12)?,
-                            ))
-                        },
-                    )?;
-                    if usage_rows.is_empty() {
-                        break;
-                    }
-
-                    for (
-                        token_usage_id,
-                        day_id,
-                        role,
-                        model_family,
-                        input_tokens,
-                        output_tokens,
-                        cache_read_tokens,
-                        cache_creation_tokens,
-                        thinking_tokens,
-                        has_tool_calls,
-                        tool_call_count,
-                        content_chars,
-                        estimated_cost_usd,
-                    ) in usage_rows
-                    {
-                        last_token_usage_id = token_usage_id;
-                        if model_family != "unknown" {
-                            session_model_family = model_family.clone();
-                        }
-                        let usage = crate::connectors::ExtractedTokenUsage {
-                            model_name: None,
-                            provider: None,
-                            input_tokens,
-                            output_tokens,
-                            cache_read_tokens,
-                            cache_creation_tokens,
-                            thinking_tokens,
-                            service_tier: None,
-                            has_tool_calls: has_tool_calls != 0,
-                            tool_call_count: u32::try_from(tool_call_count.max(0)).unwrap_or(0),
-                            data_source: franken_agent_detection::TokenDataSource::Api,
-                        };
-                        aggregate.record(
-                            &agent_slug,
-                            &source_id,
-                            day_id,
-                            &model_family,
-                            &role,
-                            &usage,
-                            content_chars,
-                            estimated_cost_usd.unwrap_or(0.0),
-                        );
-                    }
-                }
-
-                aggregate.record_session(
-                    &agent_slug,
-                    &source_id,
-                    conversation_day_id,
-                    &session_model_family,
-                );
-            }
-
-            let entries = aggregate.expand();
-            rows_created = rows_created.saturating_add(entries.len());
-            franken_update_token_daily_stats_batched_in_tx(&tx, &entries)?;
-        }
-
-        tx.commit()?;
+        let tx = conn
+            .transaction()
+            .with_context(|| "starting token_daily_stats rebuild transaction")?;
+        let now = Self::now_millis();
+        tx.execute(TOKEN_DAILY_STATS_REBUILD_BULK_SQL, rusqlite::params![now])
+            .map_err(|err| anyhow!("rebuilding token_daily_stats from token_usage: {err}"))?;
+        let rows_created: usize = tx
+            .query_row("SELECT COUNT(*) FROM token_daily_stats", [], |row| {
+                row.get::<_, i64>(0).map(|count| count.max(0) as usize)
+            })
+            .with_context(|| "counting rebuilt token_daily_stats rows")?;
+        tx.commit()
+            .with_context(|| "committing token_daily_stats rebuild transaction")?;
+        conn.execute_batch("PRAGMA wal_checkpoint(RESTART);")
+            .with_context(|| "checkpointing token_daily_stats rebuild")?;
 
         tracing::info!(
             target: "cass::analytics",
@@ -12781,195 +13107,87 @@ impl FrankenStorage {
     pub fn rebuild_analytics(&self) -> Result<AnalyticsRebuildResult> {
         let start = Instant::now();
 
-        let total_messages: i64 =
-            self.conn
-                .query_row_map("SELECT COUNT(*) FROM messages", fparams![], |row| {
-                    row.get_typed(0)
-                })?;
+        let mut conn = rusqlite::Connection::open(&self.db_path)
+            .with_context(|| format!("opening sqlite db at {}", self.db_path.display()))?;
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA cache_size = -65536;
+             PRAGMA foreign_keys = ON;
+             PRAGMA busy_timeout = 30000;",
+        )
+        .with_context(|| {
+            format!(
+                "applying sqlite analytics rebuild pragmas for {}",
+                self.db_path.display()
+            )
+        })?;
+
+        let total_messages: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
+            .with_context(|| "counting messages before analytics rebuild")?;
         tracing::info!(
             target: "cass::analytics",
             total_messages,
             "analytics_rebuild_start"
         );
 
-        let mut tx = self.conn.transaction()?;
+        let tx = conn
+            .transaction()
+            .with_context(|| "starting analytics rebuild transaction")?;
 
-        tx.execute("DELETE FROM message_metrics")?;
-        tx.execute("DELETE FROM usage_hourly")?;
-        tx.execute("DELETE FROM usage_daily")?;
-        tx.execute("DELETE FROM usage_models_daily")?;
+        tx.execute_batch(
+            "DELETE FROM message_metrics;
+             DELETE FROM usage_hourly;
+             DELETE FROM usage_daily;
+             DELETE FROM usage_models_daily;",
+        )
+        .with_context(|| "clearing analytics tables before rebuild")?;
 
-        const CHUNK_SIZE: i64 = 10_000;
-        let mut offset: i64 = 0;
-        let mut total_inserted: usize = 0;
-        let mut usage_hourly_rows: usize = 0;
-        let mut usage_daily_rows: usize = 0;
-        let mut usage_models_daily_rows: usize = 0;
+        tx.execute(ANALYTICS_REBUILD_MESSAGE_METRICS_BULK_SQL, [])
+            .with_context(|| "rebuilding message_metrics from messages")?;
+        let now = Self::now_millis();
+        tx.execute(
+            ANALYTICS_REBUILD_USAGE_HOURLY_BULK_SQL,
+            rusqlite::params![now],
+        )
+        .with_context(|| "rebuilding usage_hourly from message_metrics")?;
+        tx.execute(
+            ANALYTICS_REBUILD_USAGE_DAILY_BULK_SQL,
+            rusqlite::params![now],
+        )
+        .with_context(|| "rebuilding usage_daily from message_metrics")?;
+        tx.execute(
+            ANALYTICS_REBUILD_USAGE_MODELS_DAILY_BULK_SQL,
+            rusqlite::params![now],
+        )
+        .with_context(|| "rebuilding usage_models_daily from message_metrics")?;
 
-        loop {
-            #[allow(clippy::type_complexity)]
-            let rows: Vec<(
-                i64,
-                String,
-                String,
-                Option<serde_json::Value>,
-                Option<i64>,
-                Option<i64>,
-                String,
-                Option<i64>,
-                String,
-            )> = tx.query_map_collect(
-                // Avoid the 3-table JOIN with LIMIT/OFFSET that triggers
-                // frankensqlite's materialization fallback (see 860acb12).
-                // Inline the agent slug lookup as a correlated subquery and
-                // fall back to 'unknown' for NULL agent_id, matching the
-                // FTS / lexical rebuild paths.
-                "SELECT m.id, m.idx, m.role, m.content, m.extra_json, m.extra_bin,
-                        m.created_at,
-                        c.id AS conv_id, c.started_at AS conv_started_at,
-                        c.source_id, c.workspace_id,
-                        COALESCE((SELECT a.slug FROM agents a WHERE a.id = c.agent_id), 'unknown') AS agent_slug
-                 FROM messages m
-                 JOIN conversations c ON m.conversation_id = c.id
-                 ORDER BY m.id
-                 LIMIT ?1 OFFSET ?2",
-                fparams![CHUNK_SIZE, offset],
-                |row| {
-                    let msg_id: i64 = row.get_typed(0)?;
-                    let role: String = row.get_typed(2)?;
-                    let content: String = row.get_typed(3)?;
-                    let extra_json = row
-                        .get_typed::<Option<String>>(4)?
-                        .and_then(|s| serde_json::from_str(&s).ok())
-                        .or_else(|| {
-                            row.get_typed::<Option<Vec<u8>>>(5)
-                                .ok()
-                                .flatten()
-                                .and_then(|b| rmp_serde::from_slice(&b).ok())
-                        });
-                    let msg_ts: Option<i64> = row.get_typed(6)?;
-                    let conv_started_at: Option<i64> = row.get_typed(8)?;
-                    let source_id: String = row.get_typed(9)?;
-                    let workspace_id: Option<i64> = row.get_typed(10)?;
-                    let agent_slug: String = row.get_typed(11)?;
-                    let effective_ts = msg_ts.or(conv_started_at).unwrap_or(0);
+        let total_inserted: usize = tx
+            .query_row("SELECT COUNT(*) FROM message_metrics", [], |row| {
+                row.get::<_, i64>(0).map(|count| count.max(0) as usize)
+            })
+            .with_context(|| "counting rebuilt message_metrics rows")?;
+        let usage_hourly_rows: usize = tx
+            .query_row("SELECT COUNT(*) FROM usage_hourly", [], |row| {
+                row.get::<_, i64>(0).map(|count| count.max(0) as usize)
+            })
+            .with_context(|| "counting rebuilt usage_hourly rows")?;
+        let usage_daily_rows: usize = tx
+            .query_row("SELECT COUNT(*) FROM usage_daily", [], |row| {
+                row.get::<_, i64>(0).map(|count| count.max(0) as usize)
+            })
+            .with_context(|| "counting rebuilt usage_daily rows")?;
+        let usage_models_daily_rows: usize = tx
+            .query_row("SELECT COUNT(*) FROM usage_models_daily", [], |row| {
+                row.get::<_, i64>(0).map(|count| count.max(0) as usize)
+            })
+            .with_context(|| "counting rebuilt usage_models_daily rows")?;
 
-                    Ok((
-                        msg_id,
-                        role,
-                        content,
-                        extra_json,
-                        Some(effective_ts),
-                        workspace_id,
-                        source_id,
-                        conv_started_at,
-                        agent_slug,
-                    ))
-                },
-            )?;
-
-            if rows.is_empty() {
-                break;
-            }
-
-            let chunk_len = rows.len();
-            let mut entries = Vec::with_capacity(chunk_len);
-            let mut rollup_agg = AnalyticsRollupAggregator::new();
-
-            for (
-                msg_id,
-                role,
-                content,
-                extra_json,
-                effective_ts,
-                workspace_id,
-                source_id,
-                _conv_started_at,
-                agent_slug,
-            ) in &rows
-            {
-                let ts = effective_ts.unwrap_or(0);
-                let day_id = Self::day_id_from_millis(ts);
-                let hour_id = Self::hour_id_from_millis(ts);
-                let content_chars = content.len() as i64;
-                let content_tokens_est = content_chars / 4;
-                let extra = extra_json
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let usage =
-                    crate::connectors::extract_tokens_for_agent(agent_slug, &extra, content, role);
-                let model_info = usage
-                    .model_name
-                    .as_deref()
-                    .map(crate::connectors::normalize_model);
-                let model_family = model_info
-                    .as_ref()
-                    .map(|i| i.family.clone())
-                    .unwrap_or_else(|| "unknown".into());
-                let model_tier = model_info
-                    .as_ref()
-                    .map(|i| i.tier.clone())
-                    .unwrap_or_else(|| "unknown".into());
-                let provider = usage
-                    .provider
-                    .clone()
-                    .or_else(|| model_info.as_ref().map(|i| i.provider.clone()))
-                    .unwrap_or_else(|| "unknown".into());
-
-                let entry = MessageMetricsEntry {
-                    message_id: *msg_id,
-                    created_at_ms: ts,
-                    hour_id,
-                    day_id,
-                    agent_slug: agent_slug.clone(),
-                    workspace_id: workspace_id.unwrap_or(0),
-                    source_id: source_id.clone(),
-                    role: role.clone(),
-                    content_chars,
-                    content_tokens_est,
-                    model_name: usage.model_name.clone(),
-                    model_family,
-                    model_tier,
-                    provider,
-                    api_input_tokens: usage.input_tokens,
-                    api_output_tokens: usage.output_tokens,
-                    api_cache_read_tokens: usage.cache_read_tokens,
-                    api_cache_creation_tokens: usage.cache_creation_tokens,
-                    api_thinking_tokens: usage.thinking_tokens,
-                    api_service_tier: usage.service_tier,
-                    api_data_source: usage.data_source.as_str().to_string(),
-                    tool_call_count: usage.tool_call_count as i64,
-                    has_tool_calls: usage.has_tool_calls,
-                    has_plan: has_plan_for_role(role, content),
-                };
-                rollup_agg.record(&entry);
-                entries.push(entry);
-            }
-
-            total_inserted += franken_insert_message_metrics_batched_in_tx(&tx, &entries)?;
-            let (hourly, daily, models_daily) =
-                franken_flush_analytics_rollups_in_tx(&tx, &rollup_agg)?;
-            usage_hourly_rows += hourly;
-            usage_daily_rows += daily;
-            usage_models_daily_rows += models_daily;
-            offset += chunk_len as i64;
-
-            tracing::debug!(
-                target: "cass::analytics",
-                offset,
-                chunk = chunk_len,
-                inserted = entries.len(),
-                total = total_inserted,
-                "analytics_rebuild_chunk"
-            );
-
-            if (chunk_len as i64) < CHUNK_SIZE {
-                break;
-            }
-        }
-
-        tx.commit()?;
+        tx.commit()
+            .with_context(|| "committing analytics rebuild transaction")?;
+        conn.execute_batch("PRAGMA wal_checkpoint(RESTART);")
+            .with_context(|| "checkpointing analytics rebuild")?;
 
         let elapsed = start.elapsed();
         let elapsed_ms = elapsed.as_millis() as u64;
@@ -14458,6 +14676,17 @@ mod tests {
             Some(dir.path().join("doctor/locks/doctor-repair.lock"))
         );
         assert_eq!(doctor_mutation_lock_path_for_db_open(&scratch), None);
+    }
+
+    #[test]
+    fn corrupt_derived_table_error_detector_matches_live_failures() {
+        assert!(error_indicates_corrupt_derived_table(
+            &"OpenRead failed: could not open storage cursor on root page 35116"
+        ));
+        assert!(error_indicates_corrupt_derived_table(
+            &"database disk image is malformed"
+        ));
+        assert!(!error_indicates_corrupt_derived_table(&"no such table"));
     }
 
     #[test]
@@ -16299,6 +16528,25 @@ mod tests {
     }
 
     #[test]
+    fn analytics_rebuild_uses_bulk_sql_without_offset() {
+        assert!(
+            ANALYTICS_REBUILD_MESSAGE_METRICS_BULK_SQL
+                .contains("INSERT OR REPLACE INTO message_metrics"),
+            "analytics rebuild should bulk-populate message_metrics"
+        );
+        assert!(
+            ANALYTICS_REBUILD_USAGE_DAILY_BULK_SQL.contains("GROUP BY day_id"),
+            "analytics rebuild should bulk-populate daily rollups from message_metrics"
+        );
+        assert!(
+            !ANALYTICS_REBUILD_MESSAGE_METRICS_BULK_SQL
+                .to_ascii_uppercase()
+                .contains("OFFSET"),
+            "analytics rebuild must not use LIMIT/OFFSET pagination on large message tables"
+        );
+    }
+
+    #[test]
     fn rebuild_analytics_repopulates_from_messages() {
         use crate::model::types::{Agent, AgentKind, Conversation, Message, MessageRole};
         use std::path::PathBuf;
@@ -16447,12 +16695,11 @@ mod tests {
             "Rebuild should be fast for 3 msgs"
         );
 
-        // Verify rebuilt data matches
-        let conn = storage.raw();
+        // Verify rebuilt data matches through the same SQLite engine used by
+        // the repair path.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
         let rebuilt_mm: i64 = conn
-            .query_row_map("SELECT COUNT(*) FROM message_metrics", &[], |row| {
-                row.get_typed(0)
-            })
+            .query_row("SELECT COUNT(*) FROM message_metrics", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
             rebuilt_mm, orig_mm,
@@ -16460,9 +16707,7 @@ mod tests {
         );
 
         let rebuilt_hourly: i64 = conn
-            .query_row_map("SELECT COUNT(*) FROM usage_hourly", &[], |row| {
-                row.get_typed(0)
-            })
+            .query_row("SELECT COUNT(*) FROM usage_hourly", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
             rebuilt_hourly, orig_hourly,
@@ -16470,15 +16715,13 @@ mod tests {
         );
 
         let rebuilt_daily: i64 = conn
-            .query_row_map("SELECT COUNT(*) FROM usage_daily", &[], |row| {
-                row.get_typed(0)
-            })
+            .query_row("SELECT COUNT(*) FROM usage_daily", [], |row| row.get(0))
             .unwrap();
         assert_eq!(rebuilt_daily, orig_daily, "Rebuilt daily rows should match");
 
         let rebuilt_models_daily: i64 = conn
-            .query_row_map("SELECT COUNT(*) FROM usage_models_daily", &[], |row| {
-                row.get_typed(0)
+            .query_row("SELECT COUNT(*) FROM usage_models_daily", [], |row| {
+                row.get(0)
             })
             .unwrap();
         assert_eq!(
@@ -16488,10 +16731,10 @@ mod tests {
 
         // Verify API token data preserved through rebuild
         let rebuilt_api_input: i64 = conn
-            .query_row_map(
+            .query_row(
                 "SELECT COALESCE(SUM(api_input_tokens), 0) FROM message_metrics WHERE api_data_source = 'api'",
-                &[],
-                |row: &FrankenRow| row.get_typed(0),
+                [],
+                |row| row.get(0),
             )
             .unwrap();
         assert_eq!(
@@ -16508,19 +16751,19 @@ mod tests {
             i64,
             i64,
         ) = conn
-            .query_row_map(
+            .query_row(
                 "SELECT message_count, user_message_count, assistant_message_count, plan_message_count,
                         plan_content_tokens_est_total, plan_api_tokens_total
                  FROM usage_hourly WHERE hour_id = ?",
-                fparams![expected_hour],
-                |row: &FrankenRow| {
+                rusqlite::params![expected_hour],
+                |row| {
                     Ok((
-                        row.get_typed(0)?,
-                        row.get_typed(1)?,
-                        row.get_typed(2)?,
-                        row.get_typed(3)?,
-                        row.get_typed(4)?,
-                        row.get_typed(5)?,
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
                     ))
                 },
             )
@@ -16533,10 +16776,10 @@ mod tests {
         assert!(uh_plan_api > 0);
 
         let ud_msg: i64 = conn
-            .query_row_map(
+            .query_row(
                 "SELECT message_count FROM usage_daily WHERE day_id = ?",
-                fparams![expected_day],
-                |row| row.get_typed(0),
+                rusqlite::params![expected_day],
+                |row| row.get(0),
             )
             .unwrap();
         assert_eq!(ud_msg, 3);
@@ -16617,6 +16860,115 @@ mod tests {
 
         assert_eq!(message_count, conv.messages.len() as i64);
         assert_eq!(fts_count, conv.messages.len() as i64);
+    }
+
+    #[test]
+    fn insert_conversations_batched_with_options_can_defer_derived_updates() {
+        use crate::model::types::{Agent, AgentKind, Conversation, Message, MessageRole};
+        use std::path::PathBuf;
+
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let storage = SqliteStorage::open(&db_path).unwrap();
+        storage
+            .ensure_search_fallback_fts_consistency()
+            .expect("ensure FTS consistency before insert");
+
+        let agent = Agent {
+            id: None,
+            slug: "claude_code".into(),
+            name: "Claude Code".into(),
+            version: Some("1.0".into()),
+            kind: AgentKind::Cli,
+        };
+        let agent_id = storage.ensure_agent(&agent).unwrap();
+        let ts_ms = 1_770_551_400_000_i64;
+        let usage_json = serde_json::json!({
+            "message": {
+                "model": "claude-opus-4-6",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50
+                }
+            }
+        });
+        let conv = Conversation {
+            id: None,
+            agent_slug: "claude_code".into(),
+            workspace: None,
+            external_id: Some("defer-derived-updates".into()),
+            title: Some("Deferred derived updates".into()),
+            source_path: PathBuf::from("/tmp/defer-derived.jsonl"),
+            started_at: Some(ts_ms),
+            ended_at: Some(ts_ms + 1_000),
+            approx_tokens: None,
+            metadata_json: serde_json::Value::Null,
+            messages: vec![
+                Message {
+                    id: None,
+                    idx: 0,
+                    role: MessageRole::User,
+                    author: None,
+                    created_at: Some(ts_ms),
+                    content: "please draft a plan".into(),
+                    extra_json: serde_json::Value::Null,
+                    snippets: vec![],
+                },
+                Message {
+                    id: None,
+                    idx: 1,
+                    role: MessageRole::Agent,
+                    author: None,
+                    created_at: Some(ts_ms + 1_000),
+                    content:
+                        "## Plan\n\n1. Persist canonical rows\n2. Rebuild derived tables later"
+                            .into(),
+                    extra_json: usage_json,
+                    snippets: vec![],
+                },
+            ],
+            source_id: "local".into(),
+            origin_host: None,
+        };
+
+        let outcomes = storage
+            .insert_conversations_batched_with_options(
+                &[(agent_id, None, &conv)],
+                InsertConversationsOptions::defer_derived_updates(),
+            )
+            .unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].inserted_indices.len(), conv.messages.len());
+
+        let message_count: i64 = storage
+            .conn
+            .query_row_map("SELECT COUNT(*) FROM messages", fparams![], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        let fts_count: i64 = storage
+            .conn
+            .query_row_map("SELECT COUNT(*) FROM fts_messages", fparams![], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        let metrics_count: i64 = storage
+            .conn
+            .query_row_map("SELECT COUNT(*) FROM message_metrics", fparams![], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        let token_usage_count: i64 = storage
+            .conn
+            .query_row_map("SELECT COUNT(*) FROM token_usage", fparams![], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+
+        assert_eq!(message_count, conv.messages.len() as i64);
+        assert_eq!(fts_count, 0);
+        assert_eq!(metrics_count, 0);
+        assert_eq!(token_usage_count, 0);
     }
 
     fn make_profiled_storage_remote_conversation(
@@ -17992,7 +18344,7 @@ mod tests {
         use crate::model::types::{Agent, AgentKind, Conversation, Message, MessageRole};
         use std::path::PathBuf;
 
-        const MESSAGE_COUNT: i64 = 64;
+        const MESSAGE_COUNT: i64 = 192;
 
         let dir = TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
@@ -18071,6 +18423,27 @@ mod tests {
 
         assert_eq!(conversation_count, 1);
         assert_eq!(message_count, MESSAGE_COUNT);
+    }
+
+    #[test]
+    fn current_schema_has_message_created_at_replay_lookup_index() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let storage = SqliteStorage::open(&db_path).unwrap();
+
+        let index_count: i64 = storage
+            .conn
+            .query_row_map(
+                "SELECT COUNT(*)
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = 'idx_messages_conv_created'",
+                fparams![],
+                |row| row.get_typed(0),
+            )
+            .unwrap();
+
+        assert_eq!(index_count, 1);
     }
 
     #[test]

--- a/tests/cli_dispatch_coverage.rs
+++ b/tests/cli_dispatch_coverage.rs
@@ -339,116 +339,10 @@ fn seed_analytics_models_workspace_fixture(temp_home: &TempDir) -> PathBuf {
         .unwrap();
     }
 
-    let token_daily_rows = conn
-        .query_map_collect(
-            "SELECT tu.day_id,
-                    a.slug,
-                    tu.source_id,
-                    COALESCE(tu.model_family, 'unknown'),
-                    COUNT(*) AS api_call_count,
-                    SUM(CASE WHEN tu.role = 'user' THEN 1 ELSE 0 END) AS user_message_count,
-                    SUM(CASE WHEN tu.role IN ('assistant', 'agent') THEN 1 ELSE 0 END) AS assistant_message_count,
-                    SUM(CASE WHEN tu.role = 'tool' THEN 1 ELSE 0 END) AS tool_message_count,
-                    SUM(COALESCE(tu.input_tokens, 0)) AS total_input_tokens,
-                    SUM(COALESCE(tu.output_tokens, 0)) AS total_output_tokens,
-                    SUM(COALESCE(tu.cache_read_tokens, 0)) AS total_cache_read_tokens,
-                    SUM(COALESCE(tu.cache_creation_tokens, 0)) AS total_cache_creation_tokens,
-                    SUM(COALESCE(tu.thinking_tokens, 0)) AS total_thinking_tokens,
-                    SUM(COALESCE(tu.total_tokens, 0)) AS grand_total_tokens,
-                    SUM(COALESCE(tu.content_chars, 0)) AS total_content_chars,
-                    SUM(COALESCE(tu.tool_call_count, 0)) AS total_tool_calls,
-                    SUM(COALESCE(tu.estimated_cost_usd, 0.0)) AS estimated_cost_usd,
-                    COUNT(DISTINCT tu.conversation_id) AS session_count,
-                    MAX(tu.timestamp_ms) AS last_updated
-             FROM token_usage tu
-             JOIN agents a ON a.id = tu.agent_id
-             GROUP BY tu.day_id, a.slug, tu.source_id, COALESCE(tu.model_family, 'unknown')
-             ORDER BY tu.day_id, a.slug",
-            &[],
-            |row: &frankensqlite::Row| {
-                Ok((
-                    row.get_typed::<i64>(0)?,
-                    row.get_typed::<String>(1)?,
-                    row.get_typed::<String>(2)?,
-                    row.get_typed::<String>(3)?,
-                    row.get_typed::<i64>(4)?,
-                    row.get_typed::<i64>(5)?,
-                    row.get_typed::<i64>(6)?,
-                    row.get_typed::<i64>(7)?,
-                    row.get_typed::<i64>(8)?,
-                    row.get_typed::<i64>(9)?,
-                    row.get_typed::<i64>(10)?,
-                    row.get_typed::<i64>(11)?,
-                    row.get_typed::<i64>(12)?,
-                    row.get_typed::<i64>(13)?,
-                    row.get_typed::<i64>(14)?,
-                    row.get_typed::<i64>(15)?,
-                    row.get_typed::<f64>(16)?,
-                    row.get_typed::<i64>(17)?,
-                    row.get_typed::<i64>(18)?,
-                ))
-            },
-        )
-        .unwrap();
-
-    for (
-        day_id,
-        agent_slug,
-        source_id,
-        model_family,
-        api_call_count,
-        user_message_count,
-        assistant_message_count,
-        tool_message_count,
-        total_input_tokens,
-        total_output_tokens,
-        total_cache_read_tokens,
-        total_cache_creation_tokens,
-        total_thinking_tokens,
-        grand_total_tokens,
-        total_content_chars,
-        total_tool_calls,
-        estimated_cost_usd,
-        session_count,
-        last_updated,
-    ) in token_daily_rows
-    {
-        conn.execute_compat(
-            "INSERT OR REPLACE INTO token_daily_stats (
-                day_id, agent_slug, source_id, model_family,
-                api_call_count, user_message_count, assistant_message_count, tool_message_count,
-                total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens,
-                total_thinking_tokens, grand_total_tokens, total_content_chars, total_tool_calls,
-                estimated_cost_usd, session_count, last_updated
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
-            frankensqlite::params![
-                day_id,
-                agent_slug,
-                source_id,
-                model_family,
-                api_call_count,
-                user_message_count,
-                assistant_message_count,
-                tool_message_count,
-                total_input_tokens,
-                total_output_tokens,
-                total_cache_read_tokens,
-                total_cache_creation_tokens,
-                total_thinking_tokens,
-                grand_total_tokens,
-                total_content_chars,
-                total_tool_calls,
-                estimated_cost_usd,
-                session_count,
-                last_updated,
-            ],
-        )
-        .unwrap();
-    }
-
     drop(conn);
     let storage = coding_agent_search::storage::sqlite::FrankenStorage::open(&db_path).unwrap();
     storage.rebuild_analytics().unwrap();
+    storage.rebuild_token_daily_stats().unwrap();
 
     workspace_a
 }
@@ -1647,7 +1541,8 @@ fn missing_required_arg_returns_error() {
 // =============================================================================
 
 use coding_agent_search::{
-    AnalyticsBucketing, AnalyticsCommand, Commands, DisplayFormat, RobotFormat,
+    AnalyticsBucketing, AnalyticsCommand, AnalyticsRebuildTrack, Commands, DisplayFormat,
+    RobotFormat,
 };
 
 #[test]
@@ -3366,8 +3261,13 @@ fn analytics_rebuild_json_envelope_structure() {
         assert!(data["track_a"]["usage_hourly_rows"].is_number());
         assert!(data["track_a"]["usage_daily_rows"].is_number());
         assert!(data["track_a"]["elapsed_ms"].is_number());
-        assert_eq!(data["track"], "a");
+        assert_eq!(data["track"], "all");
         assert!(data["tracks_rebuilt"].is_array());
+        assert!(
+            data["track_b"].is_object(),
+            "analytics/rebuild must expose track_b results on default all-track success: {data}"
+        );
+        assert!(data["track_b"]["token_daily_stats_rows"].is_number());
         assert!(data["overall_elapsed_ms"].is_number());
     } else {
         // Robot-mode fatal diagnostics are emitted on stderr so stdout remains
@@ -3480,7 +3380,10 @@ fn analytics_validate_fix_noops_when_reports_are_clean() {
         "clean analytics validate --fix should finish without remaining errors: {json}"
     );
     assert_eq!(json["data"]["fix"]["requested"], true);
-    assert_eq!(json["data"]["fix"]["changed"], false);
+    assert_eq!(
+        json["data"]["fix"]["changed"], false,
+        "clean analytics validate --fix should not change anything: {json}"
+    );
     assert_eq!(
         json["data"]["fix"]["applied_repairs"]
             .as_array()
@@ -3493,7 +3396,8 @@ fn analytics_validate_fix_noops_when_reports_are_clean() {
             .as_array()
             .expect("skipped repairs array")
             .len(),
-        0
+        0,
+        "clean analytics validate --fix should not skip repairs: {json}"
     );
 }
 
@@ -3609,6 +3513,7 @@ fn analytics_rebuild_help_shows_force_flag() {
     cmd.assert()
         .success()
         .stdout(contains("--force"))
+        .stdout(contains("--track"))
         .stdout(contains("--json"));
 }
 
@@ -3620,10 +3525,85 @@ fn analytics_rebuild_parses_force_and_json_flags() {
     );
 
     match cli.command {
-        Some(Commands::Analytics(AnalyticsCommand::Rebuild { common, force })) => {
+        Some(Commands::Analytics(AnalyticsCommand::Rebuild {
+            common,
+            force,
+            track,
+        })) => {
             assert!(force, "--force should be true");
             assert!(common.json, "--json should be true");
+            assert_eq!(track, AnalyticsRebuildTrack::All);
         }
         other => panic!("expected analytics rebuild, got {other:?}"),
     }
+}
+
+#[test]
+fn analytics_rebuild_parses_track_flag() {
+    let cli = parse_cli_ok(
+        ["cass", "analytics", "rebuild", "--track", "b", "--json"],
+        "parse analytics rebuild with track b",
+    );
+
+    match cli.command {
+        Some(Commands::Analytics(AnalyticsCommand::Rebuild { track, .. })) => {
+            assert_eq!(track, AnalyticsRebuildTrack::B);
+        }
+        other => panic!("expected analytics rebuild, got {other:?}"),
+    }
+}
+
+#[test]
+fn analytics_rebuild_track_b_json_rebuilds_token_daily_stats() {
+    let tmp_home = TempDir::new().expect("temp home");
+    let _workspace = seed_analytics_models_workspace_fixture(&tmp_home);
+    let data_dir = tmp_home.path().join(".local/share/coding-agent-search");
+    let db_path = data_dir.join("agent_search.db");
+
+    let conn = rusqlite::Connection::open(&db_path).expect("open analytics db");
+    conn.execute("DELETE FROM token_daily_stats", [])
+        .expect("clear track b rollup");
+    let empty_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM token_daily_stats", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(empty_rows, 0);
+    drop(conn);
+
+    let mut cmd = base_cmd(tmp_home.path());
+    cmd.args([
+        "analytics",
+        "rebuild",
+        "--track",
+        "b",
+        "--json",
+        "--data-dir",
+        data_dir.to_str().unwrap(),
+    ]);
+
+    let output = cmd.assert().success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(stdout.trim()).expect("valid analytics rebuild JSON");
+
+    assert_eq!(json["command"], "analytics/rebuild");
+    let data = &json["data"];
+    assert_eq!(data["track"], "b");
+    assert_eq!(data["tracks_rebuilt"], json!(["b"]));
+    assert_eq!(data["track_a"], Value::Null);
+    let rebuilt_rows = data["track_b"]["token_daily_stats_rows"]
+        .as_i64()
+        .expect("track b row count");
+    assert!(
+        rebuilt_rows > 0,
+        "track b rebuild should repopulate token_daily_stats: {json}"
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).expect("reopen analytics db");
+    let stored_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM token_daily_stats", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(stored_rows, rebuilt_rows);
 }

--- a/tests/golden/robot_docs/analytics.txt.golden
+++ b/tests/golden/robot_docs/analytics.txt.golden
@@ -65,11 +65,13 @@ analytics:
     (claude_code, codex, pi_agent, factory, opencode, cursor).
 
 ### analytics rebuild
-  data.track: string ('a')
+  data.track: string ('a' | 'b' | 'all')
   data.tracks_rebuilt: [string]
   data.track_a: { message_metrics_rows, usage_hourly_rows, usage_daily_rows,
                   usage_models_daily_rows, elapsed_ms, rows_per_sec }
+  data.track_b: { token_daily_stats_rows, elapsed_ms, rows_per_sec }
   data.overall_elapsed_ms: u64
+  --track <a|b|all>: rebuild a single track or both tracks (default all)
   --force: rebuild even when rollups appear fresh
 
 ### analytics validate
@@ -100,7 +102,7 @@ analytics:
   exit 9 + retryable=true: transient DB lock/busy — retry after 1s
   exit 9 + retryable=false: schema or data issue — run 'cass analytics rebuild' first
   exit 3: no database — run 'cass index --full' to create it
-  validate errors: use 'cass analytics validate --fix --json' for safe Track A repair, or 'cass analytics rebuild --force --json' for a manual rebuild loop
+  validate errors: use 'cass analytics validate --fix --json' for safe repair, or 'cass analytics rebuild --track all --force --json' for a manual rebuild loop
 
 ## Common Workflows
   # Quick health check
@@ -115,4 +117,4 @@ analytics:
   # Validation + remediation loop
   cass analytics validate --json | jq '.data.summary'
   # If errors: rebuild then re-validate
-  cass analytics rebuild --force --json && cass analytics validate --json
+  cass analytics rebuild --track all --force --json && cass analytics validate --json


### PR DESCRIPTION
## Summary
- defer storage FTS and analytics work from watch ingest to avoid the corruption-prone inline path
- keep watch-mode lexical freshness via Tantivy while preserving recovered DB integrity
- lower normal redact memo LRU eviction telemetry from INFO to DEBUG to avoid watch log storms

## Validation
- cargo fmt --check
- cargo check --bin cass
- cargo clippy --all-targets -- -D warnings
- cargo build --release --bin cass
- recovered DB: PRAGMA quick_check => ok; foreign_key_check returned no rows
- cass status on recovered data dir: healthy, index ready, watch_active true
- lexical search for kimi returns opencode hits

## Deployment Notes
- local user service is running /home/ubuntu/.local/bin/cass 0.4.3 against /home/ubuntu/.local/share/coding-agent-search-recovered-20260513T201318Z
- cass-watch drop-in now sets CASS_WATCH_INLINE_TANTIVY=1, CASS_WATCH_OPENCODE=1, CASS_DEFER_LEXICAL_UPDATES=1, and CASS_DEFER_ANALYTICS_UPDATES=1

Direct push to upstream failed with HTTP 403 for julianknutsen, so this PR is from a fork.