### PR TITLE
fix(indexer): chunk watch-once ingest on large connector roots

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -16322,11 +16322,17 @@ fn reindex_paths_with_semantic_delta(
                 .as_mut()
                 .expect("lazy watch index must be open before ingest");
 
-            let ingest_chunk_size = if explicit_watch_once {
-                conv_count.max(1)
-            } else {
-                watch_ingest_chunk_size()
-            };
+            // The previous explicit_watch_once branch sent every discovered
+            // conversation through ingest as a single chunk. On a connector
+            // root with thousands of sessions (e.g. ~/.claude/projects with
+            // 2,500+ jsonl files), that becomes one large frankensqlite
+            // transaction plus one Tantivy commit; the run does not OOM but
+            // stops making observable forward progress for hours while the
+            // writer mutex is held. Always chunk through
+            // watch_ingest_chunk_size() so each chunk commits visibly,
+            // advances the progress counter, and releases the writer between
+            // chunks.
+            let ingest_chunk_size = watch_ingest_chunk_size();
             let capture_semantic_delta = semantic_delta.is_some();
             for chunk in convs.chunks(ingest_chunk_size) {
                 let chunk_outcome = ingest_watch_batch_with_oom_split(


### PR DESCRIPTION
## Symptom

`cass index --watch-once <large-dir>` (and the equivalent watch-mode initial backlog) on a connector root with thousands of session files hangs indefinitely in `phase=indexing`:

- Progress events stream every ~2s with `current` frozen at the first batch number (e.g. `37/2,581`).
- 99% CPU on a single producer thread; asupersync workers and Tantivy index threads all parked in `cond_wait` / `semaphore_wait_trap`.
- `cass status` reports `Healthy`.
- The stall watchdog from #196 fires `stall_detected` after `CASS_INDEX_STALL_DETECT_SECS`.

This is structurally similar to #196 but with a different root cause — the writer-token deadlock from `fd3196fb` is not involved here.

## Repro (v0.4.7 host, 2,529 claude_code jsonl files)

```
cass index --watch-once ~/.claude/projects --json
```

Before the patch: `current=37/2,581`, frozen for hours, no DB row growth, watchdog eventually fires.

After the patch: ~32-conv chunks commit visibly, `current` advances continuously, the run completes cleanly.

## Root cause

`reindex_paths_with_semantic_delta()` branched on `explicit_watch_once` and set

```rust
let ingest_chunk_size = if explicit_watch_once {
    conv_count.max(1)
} else {
    watch_ingest_chunk_size()
};
```

so an explicit watch-once over a large root sent every discovered conversation through `ingest_watch_batch_with_oom_split()` as a single chunk. That becomes one frankensqlite transaction plus one Tantivy commit, holds the writer mutex for hours, never OOMs (so the OOM-split fallback never triggers), and never advances the per-chunk progress counter.

## Fix

Always chunk through `watch_ingest_chunk_size()` (default 32, cap 512). Each chunk commits visibly, advances `current`, and releases the writer between chunks. `explicit_watch_once` is still honored elsewhere in the function for scan ordering, the watermark write, and the `since_ts` gate — only the chunk-size branch is removed.

## Verification

- Targeted repro above goes from "frozen for hours" to "completes cleanly" with the patch.
- A fresh full-corpus backfill across `claude_code` (2,573), `codex` (5,712), and `opencode` (976) — 9,261 conversations / ~900k messages — completed without re-triggering the stall.
- One-line code change; affects only the `explicit_watch_once` ingest path. Verified with `cargo check --bin cass`.
- No new tests added — the change collapses a divergent branch to the existing chunked path, which is already covered by the watch-mode tests.

Happy to add a regression test or restructure the comment if you'd like a different shape before merging.