### PR TITLE
fix(storage): skip frankensqlite advisory-lock sidecars when enumerating backup roots

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1684,7 +1684,12 @@ fn historical_bundle_root_paths(db_path: &Path) -> Vec<PathBuf> {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if name.ends_with("-wal") || name.ends_with("-shm") {
+            if name.ends_with("-wal")
+                || name.ends_with("-shm")
+                || name.ends_with("-lock-shared")
+                || name.ends_with("-lock-reserved")
+                || name.ends_with("-lock-pending")
+            {
                 continue;
             }
             if name.starts_with(&format!("{db_name}.backup."))
@@ -1702,7 +1707,12 @@ fn historical_bundle_root_paths(db_path: &Path) -> Vec<PathBuf> {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if name.ends_with("-wal") || name.ends_with("-shm") {
+            if name.ends_with("-wal")
+                || name.ends_with("-shm")
+                || name.ends_with("-lock-shared")
+                || name.ends_with("-lock-reserved")
+                || name.ends_with("-lock-pending")
+            {
                 continue;
             }
             if name.starts_with(&format!("{db_name}.")) && name.ends_with(".bak") {


### PR DESCRIPTION
## Problem

`historical_bundle_root_paths` enumerates `.backup.*` files in the data dir so it can later open them as historical-database roots. The filter that guards against opening sidecars only excluded `-wal` and `-shm`, but frankensqlite's Windows VFS also creates three advisory-lock sidecars per DB it opens (`-lock-shared`, `-lock-reserved`, `-lock-pending`).

If those sidecars get orphaned (companion bug — see [Dicklesworthstone/frankensqlite#91](https://github.com/Dicklesworthstone/frankensqlite/pull/91)), this enumeration treats them as backup roots and re-opens them as databases. Each re-open creates a fresh set of sidecars on top of the orphan path, producing chained `*-lock-pending-lock-pending-...` names.

## Real-world impact

Observed on a Windows NTFS data dir for this project: **788,972 chained orphan files (195 GB total)**, with names up to 217 characters long. Examples:

```
agent_search.db.backup.74984.1778533470460371300.0-lock-pending
agent_search.db.backup.74984.1778533470460371300.0-lock-pending-lock-pending
agent_search.db.backup.74984.1778533470460371300.0-lock-pending-lock-pending-lock-pending
...
```

This kept growing because:

1. `create_backup` makes `agent_search.db.backup.{pid}.{ts}.{nonce}` via `VACUUM INTO`.
2. frankensqlite's `WindowsOsLockFiles::open` creates 3 lock sidecars next to it.
3. `Vfs::delete` removes the main file but leaves the 3 sidecars (fixed upstream in frankensqlite#91).
4. **`historical_bundle_root_paths` later enumerates the parent dir, sees an orphan `*-lock-pending`, treats it as a backup root, and re-opens it as a DB.** ← This PR.
5. The re-open creates 3 *more* sidecars on top of the orphan path, with chained names.
6. Repeat for ~50k iterations.

## Fix

Extend the skip filter at both enumeration sites (parent dir and `backups/` subdir) to also exclude `-lock-shared`, `-lock-reserved`, `-lock-pending`. Combined with the upstream `Vfs::delete` cleanup, this stops new chains from forming.

## Validation

Applied this patch + the frankensqlite patch to v0.4.7 of cass and re-indexed 14+ hours of agent session data on Windows + WSL1:

- **Sidecar count: held at exactly 3** (one set per live DB file) across the full reindex
- Survived a machine reboot + auto-resumed maintenance run with the same count

Compared to **788,972** orphan sidecars before the patches.

## Notes

- Pure additive: the existing `-wal`/`-shm` filter is preserved.
- `is_backup_root_name` (used by `cleanup_old_backups`) is intentionally NOT changed, so any pre-existing orphan lock sidecars still get cleaned up via the normal backup-rotation path.
- Companion PR upstream: [Dicklesworthstone/frankensqlite#91](https://github.com/Dicklesworthstone/frankensqlite/pull/91) (Vfs::delete sidecar cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)