### PR TITLE
fix(daemon): add missing Commands::Daemon dispatch arm in second outer match (fixes cass daemon exit-0-without-starting)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7089,6 +7089,15 @@ async fn execute_cli(
                 Commands::Import(subcmd) => {
                     handle_import(subcmd, cli).await?;
                 }
+                #[cfg(unix)]
+                Commands::Daemon {
+                    socket,
+                    idle_timeout,
+                    max_connections,
+                    data_dir,
+                } => {
+                    run_daemon(socket, idle_timeout, max_connections, data_dir)?;
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary

`cass daemon` ships in `src/lib.rs` with a `Commands::Daemon { … } => run_daemon(…)` dispatch arm in **only one** of the two outer `match` branches that handle subcommand routing. When `cass daemon` is invoked through the second outer-match branch, the only matching arm is `_ => {}`, the function returns cleanly with exit code `0`, and the daemon is never started (no socket created, no log line, no error).

This PR adds the missing dispatch arm to the second outer match so both code paths route `cass daemon` identically through `run_daemon(...)`.

## Reproduction (before this PR)

Using the v0.4.8 release (tag `956f1d3b`, same as `main` for this code path) built on a Linux host:

```bash
RUST_LOG=info ./cass daemon \
  --data-dir /tmp/cass-data \
  --socket /tmp/cass-candidate.sock \
  --idle-timeout 30
# exit code: 0
# /tmp/cass-candidate.sock: does not exist
# stdout/stderr: no log lines beyond the tracing static-max-level warning
```

`cass --version` and `cass health --json` against the same binary both succeed, so the binary is otherwise functional — only the `daemon` subcommand fails to dispatch.

## Source-level root cause

| Source | `Commands::Daemon { … } => run_daemon(…)` arms in `src/lib.rs` |
|---|---|
| `v0.4.2`-era warm fork (known-good warm daemon in production) | **two** |
| upstream `v0.4.7` | one |
| upstream `v0.4.8` / `main` (1f20bd57) | one (around line 6611) |

The added arm in this PR is a verbatim port of the dispatch pattern that already exists in the first outer match — same parameter destructuring, same `run_daemon(...)?` call, same `#[cfg(unix)]` guard. No new dependencies, no behavior change for non-daemon subcommands.

## Diff

```diff
@@ -7089,6 +7089,15 @@ async fn execute_cli(
                 Commands::Import(subcmd) => {
                     handle_import(subcmd, cli).await?;
                 }
+                #[cfg(unix)]
+                Commands::Daemon {
+                    socket,
+                    idle_timeout,
+                    max_connections,
+                    data_dir,
+                } => {
+                    run_daemon(socket, idle_timeout, max_connections, data_dir)?;
+                }
                 _ => {}
             }
         }
```

## Scope

Single-commit, 9-line addition. Intentionally minimal so reviewers can confirm the missing arm matches the existing one. Adjacent daemon-shutdown / socket-path hardening commits from the warm-forward fork (`fix(daemon): clean stale public socket symlinks`, `fix(daemon): preserve non-socket daemon paths`, `fix(daemon): bind sockets in private runtime dirs`, `fix(daemon): short-poll idle reads so shutdown doesn't stall`, `fix(daemon,bd-a34gd): short-poll partial payload shutdown`) touch `src/daemon/core.rs`, which has refactored substantially since the v0.4.2 era. They are deferred to a separate follow-up PR after this dispatch fix lands so each layer can be reviewed independently.

## Test plan

- [x] Builds clean on Linux (`cargo build --release --bin cass`)
- [x] Dispatch arm matches the existing arm in the first outer match in shape and `#[cfg(unix)]` guard
- [ ] Verified on Worker 8 candidate build that `cass daemon` now starts and binds the socket (post-merge candidate proof gated on a separate warm-HNSW correctness review — not part of this PR's correctness)

## Operator context (FYI, not required for review)

This dispatch gap blocks promoting Worker 8 in production from `cass 0.4.2` to `cass 0.4.8`. Worker 8 is currently held on `cass 0.4.2` because the v0.4.7 and v0.4.8 candidates both hit this exit-0-without-starting behavior. Promotion is gated separately on a full warm-HNSW proof gate; this PR is the minimum-viable upstream change to unblock that work.
