### PR TITLE
feat(models): wire cass models install for rerankers (ms-marco, jina-reranker-turbo)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83794,12 +83794,22 @@ fn resolve_cli_model_name(model_name: &str) -> CliResult<&'static str> {
             Ok("snowflake-arctic-s")
         }
         "nomic-embed" | "nomic-embed-768" | "nomic-embed-text-v1.5" => Ok("nomic-embed"),
+        // Rerankers — registry already has manifests via
+        // `ModelManifest::for_reranker`; resolve aliases to canonical
+        // reranker names so `run_models_install` can route to the right
+        // manifest + directory.
+        "ms-marco"
+        | "ms-marco-minilm"
+        | "ms-marco-minilm-l-6-v2"
+        | "ms-marco-minilm-l6-v2" => Ok("ms-marco"),
+        "jina-reranker-turbo" | "jina-reranker-v1-turbo-en" => Ok("jina-reranker-turbo"),
         _ => Err(CliError {
             code: 20,
             kind: CliErrorKind::Model.kind_str(),
             message: format!(
-                "Unknown model '{}'. Supported: all-minilm-l6-v2 (alias minilm), \
-                 snowflake-arctic-s, nomic-embed.",
+                "Unknown model '{}'. Supported embedders: all-minilm-l6-v2 (alias \
+                 minilm), snowflake-arctic-s, nomic-embed. Supported rerankers: \
+                 ms-marco, jina-reranker-turbo.",
                 model_name
             ),
             hint: Some("Use 'cass models status' to see available models".into()),
@@ -85778,6 +85788,14 @@ mod cli_models_resolution_tests {
             ("nomic-embed-768", "nomic-embed"),
             ("nomic-embed-text-v1.5", "nomic-embed"),
             ("NOMIC-EMBED", "nomic-embed"),
+            // Rerankers
+            ("ms-marco", "ms-marco"),
+            ("ms-marco-minilm", "ms-marco"),
+            ("ms-marco-minilm-l-6-v2", "ms-marco"),
+            ("ms-marco-minilm-l6-v2", "ms-marco"),
+            ("MS-MARCO", "ms-marco"),
+            ("jina-reranker-turbo", "jina-reranker-turbo"),
+            ("jina-reranker-v1-turbo-en", "jina-reranker-turbo"),
         ] {
             assert_eq!(
                 resolve_cli_model_name(alias).expect("registered alias must resolve"),
@@ -85818,12 +85836,14 @@ mod cli_models_resolution_tests {
     }
 
     /// `coding_agent_session_search-v3of1`: every name that
-    /// `resolve_cli_model_name` returns MUST be a name that both
-    /// `ModelManifest::for_embedder` and `FastEmbedder::model_dir_for`
-    /// accept. Otherwise install/remove would resolve the alias and
-    /// then crash at the manifest/dir lookup. This is the cross-module
-    /// contract that the original hardcoded `all-minilm-l6-v2` check
-    /// silently maintained — making it explicit prevents drift.
+    /// `resolve_cli_model_name` returns MUST resolve to either:
+    ///   - an embedder with `ModelManifest::for_embedder` AND
+    ///     `FastEmbedder::model_dir_for` mapping, OR
+    ///   - a reranker with `ModelManifest::for_reranker` mapping.
+    /// Otherwise install/remove would resolve the alias and then crash
+    /// at the manifest/dir lookup. This is the cross-module contract
+    /// that the original hardcoded `all-minilm-l6-v2` check silently
+    /// maintained — making it explicit prevents drift.
     #[test]
     fn every_resolved_canonical_name_has_manifest_and_dir_mapping() {
         use crate::search::fastembed_embedder::FastEmbedder;
@@ -85833,13 +85853,20 @@ mod cli_models_resolution_tests {
         for canonical in ["minilm", "snowflake-arctic-s", "nomic-embed"] {
             assert!(
                 ModelManifest::for_embedder(canonical).is_some(),
-                "canonical name {canonical:?} returned by resolve_cli_model_name must have a \
-                 ModelManifest registered"
+                "embedder {canonical:?} returned by resolve_cli_model_name must have a \
+                 ModelManifest::for_embedder"
             );
             assert!(
                 FastEmbedder::model_dir_for(probe_data_dir, canonical).is_some(),
-                "canonical name {canonical:?} returned by resolve_cli_model_name must have a \
+                "embedder {canonical:?} returned by resolve_cli_model_name must have a \
                  FastEmbedder::model_dir_for mapping"
+            );
+        }
+        for canonical in ["ms-marco", "jina-reranker-turbo"] {
+            assert!(
+                ModelManifest::for_reranker(canonical).is_some(),
+                "reranker {canonical:?} returned by resolve_cli_model_name must have a \
+                 ModelManifest::for_reranker"
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83835,24 +83835,40 @@ fn run_models_install(
 
     let registry_name = resolve_cli_model_name(model_name)?;
     let data_dir = data_dir_override.unwrap_or_else(default_data_dir);
-    let model_dir =
-        FastEmbedder::model_dir_for(&data_dir, registry_name).ok_or_else(|| CliError {
+    // Route to the embedder install path or the reranker install path
+    // depending on which registry knows this canonical name. Embedders
+    // get their on-disk directory from `FastEmbedder::model_dir_for`;
+    // rerankers use `data_dir/models/<manifest.id>`, matching the
+    // convention the reranker loader expects.
+    let (model_dir, manifest) = if let Some(manifest) = ModelManifest::for_embedder(registry_name)
+    {
+        let dir =
+            FastEmbedder::model_dir_for(&data_dir, registry_name).ok_or_else(|| CliError {
+                code: 20,
+                kind: CliErrorKind::Model.kind_str(),
+                message: format!(
+                    "no model directory mapping for registered embedder '{}'",
+                    registry_name
+                ),
+                hint: None,
+                retryable: false,
+            })?;
+        (dir, manifest)
+    } else if let Some(manifest) = ModelManifest::for_reranker(registry_name) {
+        let dir = data_dir.join("models").join(&manifest.id);
+        (dir, manifest)
+    } else {
+        return Err(CliError {
             code: 20,
             kind: CliErrorKind::Model.kind_str(),
             message: format!(
-                "no model directory mapping for registered embedder '{}'",
+                "no manifest registered for '{}' (neither embedder nor reranker)",
                 registry_name
             ),
             hint: None,
             retryable: false,
-        })?;
-    let manifest = ModelManifest::for_embedder(registry_name).ok_or_else(|| CliError {
-        code: 20,
-        kind: CliErrorKind::Model.kind_str(),
-        message: format!("no manifest registered for embedder '{}'", registry_name),
-        hint: None,
-        retryable: false,
-    })?;
+        });
+    };
     let mirror_base_url = mirror
         .map(normalize_mirror_base_url)
         .transpose()
@@ -84592,21 +84608,29 @@ fn run_models_remove(
     data_dir_override: Option<PathBuf>,
 ) -> CliResult<()> {
     use crate::search::fastembed_embedder::FastEmbedder;
+    use crate::search::model_download::ModelManifest;
     use colored::Colorize;
 
     let registry_name = resolve_cli_model_name(model_name)?;
     let data_dir = data_dir_override.unwrap_or_else(default_data_dir);
-    let model_dir =
-        FastEmbedder::model_dir_for(&data_dir, registry_name).ok_or_else(|| CliError {
+    // Mirror run_models_install: pick embedder path or reranker path
+    // based on which registry knows the canonical name.
+    let model_dir = if let Some(dir) = FastEmbedder::model_dir_for(&data_dir, registry_name) {
+        dir
+    } else if let Some(manifest) = ModelManifest::for_reranker(registry_name) {
+        data_dir.join("models").join(&manifest.id)
+    } else {
+        return Err(CliError {
             code: 20,
             kind: CliErrorKind::Model.kind_str(),
             message: format!(
-                "no model directory mapping for registered embedder '{}'",
+                "no model directory mapping for '{}' (neither embedder nor reranker)",
                 registry_name
             ),
             hint: None,
             retryable: false,
-        })?;
+        });
+    };
 
     if !model_dir.is_dir() {
         println!("{} Model is not installed.", "✗".yellow());

--- a/src/search/model_download.rs
+++ b/src/search/model_download.rs
@@ -645,10 +645,15 @@ impl ModelManifest {
     /// MS MARCO MiniLM reranker manifest (baseline for bake-off).
     ///
     /// Verified: 2026-02-02 - All checksums verified from HuggingFace.
-    /// Note: Repo is ms-marco-MiniLM-L6-v2 (no hyphen between L and 6).
+    ///
+    /// Note on naming: HuggingFace repo is `cross-encoder/ms-marco-MiniLM-L6-v2`
+    /// (no hyphen between L and 6). The on-disk directory name used by the
+    /// reranker loader (`reranker_registry::canonical_dir_name`) is
+    /// `ms-marco-MiniLM-L-6-v2` (with hyphen). The manifest `id` is the
+    /// on-disk identifier, so it uses the hyphen form to match the loader.
     pub fn msmarco_reranker() -> Self {
         Self {
-            id: "ms-marco-MiniLM-L6-v2".into(),
+            id: "ms-marco-MiniLM-L-6-v2".into(),
             repo: "cross-encoder/ms-marco-MiniLM-L6-v2".into(),
             revision: "c5ee24cb16019beea0893ab7796b1df96625c6b8".into(),
             files: vec![


### PR DESCRIPTION
## Summary

Make `cass models install --model ms-marco` succeed end-to-end. The reranker manifest, downloader, and registry are already wired in v0.4.8 — only three small gaps prevent the install path from completing:

1. `ModelManifest::msmarco_reranker().id` is `"ms-marco-MiniLM-L6-v2"` but the daemon-side loader (`reranker_registry::canonical_dir_name("ms-marco")`) expects the directory `"ms-marco-MiniLM-L-6-v2"`.
2. `resolve_cli_model_name` rejects `ms-marco` (and every other reranker alias) with `Unknown model`, even though `ModelManifest::for_reranker` knows it.
3. `run_models_install` and `run_models_remove` only look up the directory via `FastEmbedder::model_dir_for` and the manifest via `ModelManifest::for_embedder`, so they cannot route a reranker.

After this PR, `cass models install --model ms-marco --data-dir <data_dir>` downloads the cross-encoder model into `<data_dir>/models/ms-marco-MiniLM-L-6-v2/`, which is exactly where the daemon-side `FastEmbedReranker` looks for it.

## Operator context (FYI)

The daemon-side reranker is already wired and loaded at startup if the model directory exists. Currently every fresh daemon emits:

```
WARN Failed to load reranker, reranking unavailable
  error=Reranking failed for ms-marco-minilm-l6-v2: reranker model directory not found:
  <data_dir>/models/ms-marco-MiniLM-L-6-v2.
  Results still valid with original RRF scores.
```

This is benign (RRF scores still ship), but it is a permanent degraded state because there is no working install path to populate that directory. This PR fixes the install path without a shim directory.

## Commits

### 1. `fix(models): align ms-marco reranker manifest id with loader directory name`

Manifest `id` changes from `ms-marco-MiniLM-L6-v2` to `ms-marco-MiniLM-L-6-v2` (with hyphen) to match the directory name the reranker loader expects. The HuggingFace `repo` field stays `cross-encoder/ms-marco-MiniLM-L6-v2` (verified canonical HuggingFace repo name via the live page).

### 2. `feat(models): accept reranker aliases in CLI model resolver`

`resolve_cli_model_name` learns four `ms-marco` aliases (`ms-marco`, `ms-marco-minilm`, `ms-marco-minilm-l-6-v2`, `ms-marco-minilm-l6-v2`) and the `jina-reranker-turbo` aliases. Bake-off-eligible cross-encoders that don't have `for_reranker` manifests yet (`bge-reranker-v2`, `jina-reranker-v2`) are intentionally NOT added so the resolver can't return canonical names the install path can't satisfy. The "unknown model" error message is widened to list both embedder and reranker names so operators discover them via the error. Tests are extended to cover the new aliases and to allow either `for_embedder` or `for_reranker` to satisfy the cross-module contract.

### 3. `feat(models): route install/remove to reranker manifest when applicable`

`run_models_install` and `run_models_remove` now pick the on-disk directory based on which registry knows the canonical name:
- If `ModelManifest::for_embedder(name)`, use `FastEmbedder::model_dir_for` (unchanged behavior for the 3 embedders).
- Else if `ModelManifest::for_reranker(name)`, use `<data_dir>/models/<manifest.id>` so the directory matches the loader's expectation.
- Otherwise return the existing not-registered error (generalized to mention both possibilities).

## Diff size

```
src/lib.rs                   | 103 ++++++++++++++++++++++++++++++++-----------
src/search/model_download.rs |   9 +++-
2 files changed, 84 insertions(+), 28 deletions(-)
```

## Test plan

- [x] `cargo test cli_models_resolution_tests::resolve_cli_model_name_accepts_every_registered_embedder_alias` (extended to cover the new reranker aliases)
- [x] `cargo test cli_models_resolution_tests::every_resolved_canonical_name_has_manifest_and_dir_mapping` (extended to assert reranker names resolve through `for_reranker`)
- [ ] End-to-end verified on a candidate binary against Worker 8's data dir (`cass models install --model ms-marco --data-dir /home/gurpreet/cass-worker8/data --yes` populates `<data_dir>/models/ms-marco-MiniLM-L-6-v2/`, daemon restart logs `INFO Loading reranker model_dir=...` with no "Failed to load reranker" line) — gated on the dispatch fix PR #241 landing or being applied so the daemon can be built and run.

## Related

- Sibling PR #241 (`fix(daemon): add missing Commands::Daemon dispatch arm in second outer match`) — needed for the daemon to actually start on v0.4.7+ builds and consume the installed reranker.

## Followups not in this PR

- Surface installed/missing rerankers in `cass models status` (currently embedders-only).
- Add `for_reranker` manifests for the bake-off-eligible cross-encoders (`bge-reranker-v2`, `jina-reranker-v2`) so their aliases can be added to the resolver.
