### PR TITLE
feat(connectors): support Hermes (Nous Research) as a first-class agent

### DIFF
--- a/src/connectors/hermes.rs
+++ b/src/connectors/hermes.rs
@@ -1,0 +1,3 @@
+//! Implementation lives in `franken_agent_detection::connectors::hermes`.
+
+pub use franken_agent_detection::HermesConnector;

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -51,6 +51,7 @@ pub mod crush;
 pub mod cursor;
 pub mod factory;
 pub mod gemini;
+pub mod hermes;
 pub mod kimi;
 pub mod openclaw;
 pub mod opencode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8230,6 +8230,7 @@ fn capabilities_connector_names() -> Vec<String> {
         "pi_agent",
         "factory",
         "openclaw",
+        "hermes",
     ];
 
     let mut connectors: Vec<String> = preferred.iter().map(|name| (*name).to_string()).collect();


### PR DESCRIPTION
## What

Makes **Hermes** (Nous Research agent) a first-class CASS connector, so `cass index` picks up `~/.hermes/sessions/session_*.json` and `cass search --agent hermes` works, on par with claude_code/codex/cursor.

Today `cass capabilities` lists 18 connectors and Hermes is not among them — Hermes sessions are invisible to search even after a re-index, because there is no connector that parses them.

## Changes (thin — the parsing lives in FAD)

- `src/connectors/hermes.rs`: re-export stub (`pub use franken_agent_detection::HermesConnector;`), matching the existing per-connector stub convention.
- `src/connectors/mod.rs`: `pub mod hermes;`
- `src/lib.rs`: add `"hermes"` to the capabilities preferred-connector list for stable ordering. (The factory fallback in `capabilities_connector_names()` would append it regardless; this just pins the order.)

`public_connector_slug` passes `"hermes"` through unchanged — no `claude`→`claude_code`-style remap needed.

## Depends on

The substantive connector (parser + detection + tests) is in the companion PR:
**Dicklesworthstone/franken_agent_detection#12**

CASS pins FAD via a local `path` dependency, so this PR should land after (or together with) the FAD bump.

## Verification

- FAD side: 22 new unit tests + full suite green (610 passed). `HermesConnector` confirmed exported at `franken_agent_detection::HermesConnector` and registered in `get_connector_factories()` under slug `hermes` (so this stub resolves and the indexer picks it up).
- Note: I could not run a full local `cass index` end-to-end because an unrelated sibling path-dep (`asupersync`) isn't present in my checkout; the change is mechanically minimal (stub + slug) and relies on the verified FAD registration. CI (with the full sibling set) will exercise the end-to-end path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)