### PR TITLE
fix: embedding progress visibility, doctor perf, stall watchdog, models install --json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -223,9 +223,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -544,13 +544,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -593,15 +593,15 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -841,13 +841,13 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "coding-agent-search"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -907,7 +907,7 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "qrcode",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_chacha 0.10.0",
  "rayon",
  "regex",
@@ -939,11 +939,11 @@ dependencies = [
  "unicode-width",
  "url",
  "urlencoding",
- "vergen 10.0.0",
+ "vergen 10.0.1",
  "wait-timeout",
  "walkdir",
  "which",
- "wide 1.4.0",
+ "wide 1.5.0",
  "xxhash-rust",
  "zeroize",
 ]
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1384,6 +1384,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,7 +1445,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1517,7 +1547,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1565,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1664,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1674,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1998,7 +2028,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "wide 1.4.0",
+ "wide 1.5.0",
 ]
 
 [[package]]
@@ -2031,7 +2061,7 @@ dependencies = [
  "serde_json",
  "tokenizers",
  "tracing",
- "wide 1.4.0",
+ "wide 1.5.0",
 ]
 
 [[package]]
@@ -2146,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "fsqlite-error"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f56b6ab3fae2b1d360f6561453ce23ef65d6f635d47b57d3671b8f3da227dd"
+checksum = "8e6adfc90ed64419d85ac80532132f9ec7480f1f15a00fc620a6ebec2d76d75c"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2201,7 +2231,7 @@ dependencies = [
  "fsqlite-func",
  "fsqlite-types",
  "getrandom 0.4.3",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tracing",
 ]
 
@@ -3599,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -3709,9 +3739,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -3748,18 +3778,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3981,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3994,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -4005,9 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
 ]
@@ -4023,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -4045,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4101,10 +4131,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -4116,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4127,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -4152,13 +4183,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -4174,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4227,9 +4257,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -4247,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
 dependencies = [
  "cc",
  "libc",
@@ -4261,9 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -4306,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -4412,15 +4442,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4468,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4648,9 +4678,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4828,9 +4858,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4859,18 +4889,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -5305,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5315,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -5376,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -5396,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5431,9 +5461,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -5473,11 +5503,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -5547,9 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -5613,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5636,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -5766,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -5803,9 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "ring",
@@ -5817,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5838,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5909,15 +5939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5931,12 +5952,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -6062,24 +6077,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6167,9 +6181,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -6281,9 +6295,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6325,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "ssh2"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
+checksum = "c95eb3c09e378543395a3fa9796f897861862466ee331d59140ade4ea0dcfdfc"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -6373,9 +6387,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6680,12 +6694,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -6697,15 +6710,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7005,9 +7018,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -7092,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -7192,9 +7205,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7232,15 +7245,15 @@ dependencies = [
 
 [[package]]
 name = "vergen"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdf18a54cf91b4d98a8e8b67f6321606539fbcdcac02536286ad1de37b53fd2"
+checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
 dependencies = [
  "anyhow",
  "bon",
  "rustversion",
  "time",
- "vergen-lib 10.0.0",
+ "vergen-lib 10.0.1",
 ]
 
 [[package]]
@@ -7271,9 +7284,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910e8471e27130bbc019e9bfa6bda16dfc4c6dd7c5d0793da70a9256caeae984"
+checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
 dependencies = [
  "anyhow",
  "bon",
@@ -7339,18 +7352,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7361,9 +7374,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7371,9 +7384,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7381,9 +7394,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7394,18 +7407,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7423,18 +7436,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]
@@ -7451,9 +7464,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch 1.0.0",
@@ -7902,9 +7915,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yaml-rust"
@@ -7923,9 +7936,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7946,18 +7959,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7987,18 +8000,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-agent-search"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2024"
 authors = ["Jeffrey Emanuel"]
 description = "Unified TUI search over local coding agent histories"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -77,6 +77,7 @@ pub struct DoctorCommandRequest {
     pub dry_run: bool,
     pub yes: bool,
     pub plan_fingerprint: Option<String>,
+    pub full: bool,
 }
 
 impl DoctorCommandSurface {
@@ -184,6 +185,7 @@ impl DoctorCommandRequest {
             verbose,
             force_rebuild,
             allow_repeated_repair,
+            false,
         )
     }
 
@@ -208,6 +210,7 @@ impl DoctorCommandRequest {
         verbose: bool,
         force_rebuild: bool,
         allow_repeated_repair: bool,
+        full: bool,
     ) -> CliResult<Self> {
         let backup_command = if backups_list {
             Some(DoctorBackupCommand::List)
@@ -295,6 +298,7 @@ impl DoctorCommandRequest {
             dry_run,
             yes,
             plan_fingerprint,
+            full,
         };
         request.validate()?;
         Ok(request)
@@ -802,6 +806,7 @@ pub(crate) fn execute_doctor_command_with_wrap(
         request.surface,
         request.mode,
         request.plan_fingerprint,
+        request.full,
         wrap,
     )
 }
@@ -971,6 +976,7 @@ mod tests {
             dry_run: false,
             yes: false,
             plan_fingerprint: None,
+            full: false,
         };
         let err = request
             .validate()
@@ -1285,6 +1291,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .expect_err("archive-normalize apply must reject an empty fingerprint");
         assert_eq!(archive_normalize_err.code, 2);
@@ -1308,6 +1315,7 @@ mod tests {
             false,
             true,
             Some(String::new()),
+            false,
             false,
             false,
             false,
@@ -1340,6 +1348,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .expect("archive-scan should map to read-only scan mode");
 
@@ -1368,6 +1377,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .expect_err("archive-scan must reject repair dry-run controls");
         assert!(err.message.contains("always read-only"));
@@ -1392,6 +1402,7 @@ mod tests {
             false,
             false,
             None,
+            false,
             false,
             false,
             false,
@@ -1425,6 +1436,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .expect("archive-normalize apply should require yes and fingerprint");
 
@@ -1450,6 +1462,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
             false,
             false,

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -952,8 +952,12 @@ impl PartialEq<CanonicalMutationCounts> for NonWatchIngestOutcome {
 pub struct IndexingProgress {
     pub total: AtomicUsize,
     pub current: AtomicUsize,
-    // Simple phase indicator: 0=Idle, 1=Scanning, 2=Indexing
+    // Simple phase indicator: 0=Idle, 1=Scanning, 2=Indexing, 3=Embedding
     pub phase: AtomicUsize,
+    /// Number of messages embedded so far during the semantic embedding phase.
+    pub semantic_current: AtomicUsize,
+    /// Total number of messages queued for embedding during the semantic embedding phase.
+    pub semantic_total: AtomicUsize,
     pub is_rebuilding: AtomicBool,
     /// Number of coding agents discovered so far during scanning
     pub discovered_agents: AtomicUsize,
@@ -1052,12 +1056,13 @@ impl IndexingProgress {
         match phase {
             1 => "scanning",
             2 => "indexing",
+            3 => "embedding",
             _ => "preparing",
         }
     }
 
     /// Human-readable label for the current phase.
-    /// 0 = preparing (pre-scan), 1 = scanning, 2 = indexing.
+    /// 0 = preparing (pre-scan), 1 = scanning, 2 = indexing, 3 = embedding.
     pub fn phase_label(&self) -> &'static str {
         Self::phase_label_for(self.phase.load(Ordering::Relaxed))
     }
@@ -14373,6 +14378,10 @@ pub fn run_index(
         } else {
             tracing::info!(embedder = %opts.embedder, "starting semantic indexing");
 
+            if let Some(progress) = opts.progress.as_ref() {
+                progress.phase.store(3, Ordering::Relaxed);
+            }
+
             let semantic_indexer = SemanticIndexer::new(&opts.embedder, Some(&opts.data_dir))?;
             let mut semantic_read_storage = FrankenStorage::open_readonly(&opts.db_path)
                 .with_context(|| {
@@ -14395,7 +14404,12 @@ pub fn run_index(
             });
 
             // Generate embeddings
-            let embedded_messages = semantic_indexer.embed_messages(&embedding_inputs)?;
+            let embedded_messages = match opts.progress.as_ref() {
+                Some(progress) => {
+                    semantic_indexer.embed_messages_with_progress(&embedding_inputs, progress)?
+                }
+                None => semantic_indexer.embed_messages(&embedding_inputs)?,
+            };
             tracing::info!(
                 embedded_count = embedded_messages.len(),
                 "generated embeddings"

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
@@ -15,6 +17,7 @@ use frankensqlite::compat::{ConnectionExt, ParamValue, RowExt};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rayon::prelude::*;
 
+use crate::indexer::IndexingProgress;
 use crate::indexer::memoization::{
     ContentAddressedMemoCache, MemoCacheAuditRecord, MemoContentHash, MemoKey, MemoLookup,
 };
@@ -1623,23 +1626,47 @@ impl SemanticIndexer {
     }
 
     pub fn embed_messages(&self, messages: &[EmbeddingInput]) -> Result<Vec<EmbeddedMessage>> {
-        self.embed_messages_with_sink(messages, &SemanticProgressSink::disabled())
+        self.embed_messages_with_sink(messages, &SemanticProgressSink::disabled(), None)
+    }
+
+    /// Variant of [`embed_messages`] that reports batch-level progress into
+    /// the shared [`IndexingProgress`] struct so the CLI spinner and TUI can
+    /// render live embedding progress instead of a bare "preparing" state.
+    pub fn embed_messages_with_progress(
+        &self,
+        messages: &[EmbeddingInput],
+        progress: &Arc<IndexingProgress>,
+    ) -> Result<Vec<EmbeddedMessage>> {
+        self.embed_messages_with_sink(messages, &SemanticProgressSink::disabled(), Some(progress))
     }
 
     /// Variant of [`embed_messages`] that emits `embed_batch_*` events
     /// into the given JSONL sink. The sink is silent unless
     /// `CASS_SEMANTIC_PROGRESS_JSONL` is set, so this path is safe to
-    /// take in production.
+    /// take in production. `progress`, when set, receives live batch-level
+    /// updates for the CLI spinner / TUI to render.
     pub fn embed_messages_with_sink(
         &self,
         messages: &[EmbeddingInput],
         sink: &SemanticProgressSink,
+        progress: Option<&Arc<IndexingProgress>>,
     ) -> Result<Vec<EmbeddedMessage>> {
         if messages.is_empty() {
             return Ok(Vec::new());
         }
 
-        let show_progress = std::io::stderr().is_terminal();
+        if let Some(progress) = progress {
+            progress
+                .semantic_total
+                .store(messages.len(), Ordering::Relaxed);
+            progress.semantic_current.store(0, Ordering::Relaxed);
+        }
+
+        // When the shared IndexingProgress is wired up, the outer CLI
+        // spinner / TUI renders embedding progress from those atomics, so
+        // suppress this indicatif bar to avoid two competing progress
+        // displays fighting over the same terminal line.
+        let show_progress = std::io::stderr().is_terminal() && progress.is_none();
         let pb = ProgressBar::new(saturating_u64_from_usize(messages.len()));
         if show_progress {
             let style = ProgressStyle::default_bar()
@@ -1724,6 +1751,11 @@ impl SemanticIndexer {
                 flush_prepared_batch(batch, &mut embeddings, &pb, self.embedder.as_ref())?;
                 let elapsed_ms = saturating_u64_from_millis(batch_started.elapsed().as_millis());
                 rows_processed = rows_processed.saturating_add(batch_rows);
+                if let Some(progress) = progress {
+                    progress
+                        .semantic_current
+                        .store(rows_processed as usize, Ordering::Relaxed);
+                }
                 if warn_after_ms > 0 && elapsed_ms > warn_after_ms {
                     tracing::warn!(
                         batch_index,
@@ -2154,7 +2186,7 @@ impl SemanticIndexer {
             .as_ref()
             .map_or(0, |checkpoint| checkpoint.docs_embedded);
 
-        let embeddings = self.embed_messages_with_sink(messages, sink)?;
+        let embeddings = self.embed_messages_with_sink(messages, sink, None)?;
         let embedded_docs = u64::try_from(embeddings.len()).unwrap_or(u64::MAX);
         if sink.is_active() {
             sink.emit(

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -726,18 +726,19 @@ pub(crate) fn saturating_u32_from_i64(raw: i64) -> u32 {
     }
 }
 
-fn canonical_embedding_created_at_ms(message_id: u64, created_at: Option<i64>) -> i64 {
-    // `created_at_ms` feeds time-range filters in the vector index
-    // (src/search/vector_index.rs range predicates) and contributes to
-    // `stable_hit_hash`. Defaulting a NULL created_at to 0 silently
-    // masquerades the message as Unix-epoch (1970), which is indistinguishable
-    // from a legitimately-ancient row in downstream filters. Emit a warn
-    // so operators see NULL-created_at rows in the logs instead of only
-    // finding them by puzzling over 1970 timestamps in semantic hits.
-    created_at.unwrap_or_else(|| {
+// Falls back to conversation started_at when message created_at is NULL.
+// This value feeds vector-index time-range filters and stable_hit_hash;
+// defaulting to 0 masquerades the row as 1970, breaking both.
+fn canonical_embedding_created_at_ms(
+    message_id: u64,
+    created_at: Option<i64>,
+    conversation_started_at: Option<i64>,
+) -> i64 {
+    created_at.or(conversation_started_at).unwrap_or_else(|| {
         tracing::warn!(
             message_id,
-            "semantic backfill: row has NULL created_at; defaulting to 0 (Unix epoch). \
+            "semantic backfill: row has NULL created_at and no conversation started_at; \
+             defaulting to 0 (Unix epoch). \
              Downstream time-range filters will treat this message as 1970-01-01."
         );
         0
@@ -783,6 +784,7 @@ fn embedding_input_from_packet_message(
     agent_id: u32,
     workspace_id: u32,
     source_id_hash: u32,
+    conversation_started_at: Option<i64>,
     message: &crate::model::conversation_packet::ConversationPacketMessage,
 ) -> Option<EmbeddingInput> {
     let Some(raw_message_id) = message.message_id else {
@@ -803,7 +805,11 @@ fn embedding_input_from_packet_message(
     };
     Some(EmbeddingInput {
         message_id,
-        created_at_ms: canonical_embedding_created_at_ms(message_id, message.created_at),
+        created_at_ms: canonical_embedding_created_at_ms(
+            message_id,
+            message.created_at,
+            conversation_started_at,
+        ),
         agent_id,
         workspace_id,
         source_id: source_id_hash,
@@ -836,6 +842,7 @@ fn embedding_inputs_from_conversation_packet(
                         agent_id,
                         workspace_id,
                         source_id_hash,
+                        row.started_at,
                         message,
                     )
                 })
@@ -968,6 +975,7 @@ pub(crate) fn semantic_inputs_from_packets(
                 context.agent_id,
                 context.workspace_id,
                 source_id_hash,
+                packet.payload.timestamps.started_at,
                 message,
             ) {
                 inputs.push(input);
@@ -4631,6 +4639,25 @@ mod tests {
         assert!(
             err.contains("length mismatch"),
             "error should mention length mismatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn canonical_created_at_falls_back_to_conversation_started_at() {
+        assert_eq!(
+            canonical_embedding_created_at_ms(1, Some(100), Some(200)),
+            100,
+            "should prefer message created_at when present"
+        );
+        assert_eq!(
+            canonical_embedding_created_at_ms(2, None, Some(200)),
+            200,
+            "should fall back to conversation started_at when created_at is NULL"
+        );
+        assert_eq!(
+            canonical_embedding_created_at_ms(3, None, None),
+            0,
+            "should default to 0 when both are NULL"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,6 +959,10 @@ pub enum Commands {
         /// Permit a mutating repair even when a previous failure marker exists
         #[arg(long)]
         allow_repeated_repair: bool,
+        /// Run exhaustive verification including per-blob blake3 content hashing.
+        /// Without this flag, raw mirror verification uses size-only checks for speed.
+        #[arg(long, default_value_t = false)]
+        full: bool,
 
         // --- world-class-doctor pass-2: per-run artifact subcommands ---
         /// List per-run artifact directories under `<data_dir>/doctor/runs/`. Read-only.
@@ -2166,6 +2170,9 @@ pub enum ModelsCommand {
         /// Override data dir
         #[arg(long)]
         data_dir: Option<PathBuf>,
+        /// Output as JSON (`--robot` also works)
+        #[arg(long, visible_alias = "robot")]
+        json: bool,
     },
     /// Verify model integrity (SHA256 checksums)
     Verify {
@@ -7536,6 +7543,7 @@ async fn execute_cli(
                     verbose,
                     force_rebuild,
                     allow_repeated_repair,
+                    full,
                     ls,
                     undo,
                     robot_triage,
@@ -7768,6 +7776,7 @@ async fn execute_cli(
                             verbose,
                             force_rebuild,
                             allow_repeated_repair,
+                            full,
                         )?;
                         doctor::execute_doctor_command_with_wrap(request, wrap)?;
                     }
@@ -32328,7 +32337,7 @@ fn capture_doctor_forensic_bundle(
     }
 
     let source_inventory = collect_doctor_source_inventory(input.data_dir, input.db_path);
-    let raw_mirror_report = collect_doctor_raw_mirror_report(input.data_dir);
+    let raw_mirror_report = collect_doctor_raw_mirror_report(input.data_dir, true);
     let quarantine_report = input
         .quarantine_report
         .cloned()
@@ -37019,6 +37028,7 @@ fn doctor_verify_raw_mirror_manifest(
     root: &Path,
     manifest_path: &Path,
     manifest: DoctorRawMirrorManifestFile,
+    full: bool,
 ) -> DoctorRawMirrorManifestReport {
     let manifest_path_string = manifest_path.display().to_string();
     let invalid =
@@ -37123,39 +37133,56 @@ fn doctor_verify_raw_mirror_manifest(
         ),
         Ok(metadata) => {
             let size_matches = metadata.len() == manifest.blob_size_bytes;
-            match doctor_file_blake3(&blob_path) {
-                Ok(actual_hash) if actual_hash == manifest.blob_blake3 && size_matches => {
-                    match manifest_checksum_status {
-                        DoctorArtifactChecksumStatus::Mismatched => (
-                            DoctorArtifactChecksumStatus::Matched,
-                            "manifest_drift".to_string(),
-                            Some("manifest_blake3 does not match manifest metadata".to_string()),
-                        ),
-                        DoctorArtifactChecksumStatus::NotRecorded => (
-                            DoctorArtifactChecksumStatus::Matched,
-                            "manifest_unverified".to_string(),
-                            Some(
-                                "manifest_blake3 is not recorded; metadata integrity cannot be verified"
-                                    .to_string(),
+            if full {
+                match doctor_file_blake3(&blob_path) {
+                    Ok(actual_hash) if actual_hash == manifest.blob_blake3 && size_matches => {
+                        match manifest_checksum_status {
+                            DoctorArtifactChecksumStatus::Mismatched => (
+                                DoctorArtifactChecksumStatus::Matched,
+                                "manifest_drift".to_string(),
+                                Some("manifest_blake3 does not match manifest metadata".to_string()),
                             ),
-                        ),
-                        _ => (
-                            DoctorArtifactChecksumStatus::Matched,
-                            "verified".to_string(),
-                            None,
-                        ),
+                            DoctorArtifactChecksumStatus::NotRecorded => (
+                                DoctorArtifactChecksumStatus::Matched,
+                                "manifest_unverified".to_string(),
+                                Some(
+                                    "manifest_blake3 is not recorded; metadata integrity cannot be verified"
+                                        .to_string(),
+                                ),
+                            ),
+                            _ => (
+                                DoctorArtifactChecksumStatus::Matched,
+                                "verified".to_string(),
+                                None,
+                            ),
+                        }
                     }
+                    Ok(_) => (
+                        DoctorArtifactChecksumStatus::Mismatched,
+                        "checksum_mismatch".to_string(),
+                        Some("blob bytes or size do not match manifest".to_string()),
+                    ),
+                    Err(err) => (
+                        DoctorArtifactChecksumStatus::Mismatched,
+                        "checksum_mismatch".to_string(),
+                        Some(format!("failed to hash blob: {err}")),
+                    ),
                 }
-                Ok(_) => (
+            } else if size_matches {
+                (
+                    DoctorArtifactChecksumStatus::NotRecorded,
+                    "size_verified".to_string(),
+                    None,
+                )
+            } else {
+                (
                     DoctorArtifactChecksumStatus::Mismatched,
-                    "checksum_mismatch".to_string(),
-                    Some("blob bytes or size do not match manifest".to_string()),
-                ),
-                Err(err) => (
-                    DoctorArtifactChecksumStatus::Mismatched,
-                    "checksum_mismatch".to_string(),
-                    Some(format!("failed to hash blob: {err}")),
-                ),
+                    "size_mismatch".to_string(),
+                    Some(
+                        "blob size does not match manifest (run with --full for content hash verification)"
+                            .to_string(),
+                    ),
+                )
             }
         }
         Err(_) => (
@@ -37252,16 +37279,18 @@ fn doctor_raw_mirror_size_warning(total_blob_bytes: u64, threshold_bytes: u64) -
     })
 }
 
-fn collect_doctor_raw_mirror_report(data_dir: &Path) -> DoctorRawMirrorReport {
+fn collect_doctor_raw_mirror_report(data_dir: &Path, full: bool) -> DoctorRawMirrorReport {
     collect_doctor_raw_mirror_report_with_threshold(
         data_dir,
         doctor_raw_mirror_size_warn_threshold_bytes(),
+        full,
     )
 }
 
 fn collect_doctor_raw_mirror_report_with_threshold(
     data_dir: &Path,
     size_warn_threshold_bytes: u64,
+    full: bool,
 ) -> DoctorRawMirrorReport {
     let root = doctor_raw_mirror_root(data_dir);
     let root_path = root.display().to_string();
@@ -37329,9 +37358,9 @@ fn collect_doctor_raw_mirror_report_with_threshold(
                             .ok()
                             .and_then(|content| serde_json::from_str(&content).ok())
                         {
-                            Some(manifest) => {
-                                doctor_verify_raw_mirror_manifest(data_dir, &root, path, manifest)
-                            }
+                            Some(manifest) => doctor_verify_raw_mirror_manifest(
+                                data_dir, &root, path, manifest, full,
+                            ),
                             None => doctor_raw_mirror_invalid_manifest_report(
                                 data_dir,
                                 path,
@@ -37640,7 +37669,7 @@ fn doctor_archive_finding(input: DoctorArchiveFindingInput<'_>) -> DoctorArchive
 
 fn build_doctor_archive_scan_context(data_dir: &Path, db_path: &Path) -> DoctorArchiveScanContext {
     let source_inventory = collect_doctor_source_inventory(data_dir, db_path);
-    let raw_mirror = collect_doctor_raw_mirror_report(data_dir);
+    let raw_mirror = collect_doctor_raw_mirror_report(data_dir, true);
     let raw_mirror_backfill =
         collect_doctor_raw_mirror_backfill_report(data_dir, db_path, &raw_mirror, false);
     let sole_copy_warnings = build_doctor_sole_copy_warnings(&raw_mirror_backfill);
@@ -47568,7 +47597,7 @@ fn build_doctor_baseline_snapshot(
     let source_inventory = collect_doctor_source_inventory(data_dir, db_path);
     let remote_source_sync =
         collect_doctor_remote_source_sync_report(data_dir, &sources_path, &source_inventory);
-    let raw_mirror = collect_doctor_raw_mirror_report(data_dir);
+    let raw_mirror = collect_doctor_raw_mirror_report(data_dir, true);
     let raw_mirror_backfill =
         collect_doctor_raw_mirror_backfill_report(data_dir, db_path, &raw_mirror, false);
     let sole_copy_warnings = build_doctor_sole_copy_warnings(&raw_mirror_backfill);
@@ -62249,7 +62278,7 @@ mod doctor_asset_taxonomy_tests {
             }],
         );
         write_raw_mirror_test_manifest(&data_dir, &manifest, raw_bytes);
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(raw_mirror.status, "verified");
         let source_inventory =
             build_doctor_source_inventory_report(&data_dir, false, None, Vec::new(), Vec::new());
@@ -62378,7 +62407,7 @@ mod doctor_asset_taxonomy_tests {
         );
         write_raw_mirror_test_manifest(&data_dir, &manifest_a, bytes_a);
         write_raw_mirror_test_manifest(&data_dir, &manifest_b, bytes_b);
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         let source_inventory =
             build_doctor_source_inventory_report(&data_dir, false, None, Vec::new(), Vec::new());
         let source_authority =
@@ -64804,7 +64833,7 @@ paths = ["~/.claude/projects"]
             Vec::new(),
         );
         write_raw_mirror_test_manifest(&data_dir, &unlinked_manifest, unlinked_bytes);
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
 
         let backfill = DoctorRawMirrorBackfillReport {
             schema_version: 1,
@@ -65142,7 +65171,7 @@ paths = ["~/.claude/projects"]
             }],
         );
         write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         let report = build_doctor_source_authority_report(&db_path, &source_inventory, &raw_mirror);
 
         assert_eq!(
@@ -65182,7 +65211,7 @@ paths = ["~/.claude/projects"]
         let db_path = data_dir.join("agent_search.db");
         let source_inventory =
             build_doctor_source_inventory_report(&data_dir, false, None, Vec::new(), Vec::new());
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         let report = build_doctor_source_authority_report(&db_path, &source_inventory, &raw_mirror);
 
         assert_eq!(report.decision, DoctorSourceAuthorityDecision::Refused);
@@ -65214,7 +65243,7 @@ paths = ["~/.claude/projects"]
         }];
         let source_inventory =
             build_doctor_source_inventory_report(&data_dir, true, None, rows, Vec::new());
-        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         let report = build_doctor_source_authority_report(&db_path, &source_inventory, &raw_mirror);
 
         assert_eq!(report.coverage_delta.remote_source_count, 1);
@@ -65426,7 +65455,7 @@ paths = ["~/.claude/projects"]
         manifest.manifest_blake3 = Some(doctor_raw_mirror_manifest_blake3(&manifest));
         write_raw_mirror_test_manifest(&data_dir, &manifest, raw_bytes);
 
-        let report = collect_doctor_raw_mirror_report(&data_dir);
+        let report = collect_doctor_raw_mirror_report(&data_dir, true);
         let payload = serde_json::to_value(&report).expect("raw mirror report json");
         let rendered = serde_json::to_string(&payload).expect("raw mirror rendered json");
 
@@ -65559,7 +65588,7 @@ paths = ["~/.claude/projects"]
         std::fs::create_dir_all(&tmp_dir).expect("create tmp dir");
         std::fs::write(tmp_dir.join("capture.tmp"), b"partial").expect("write tmp");
 
-        let report = collect_doctor_raw_mirror_report(&data_dir);
+        let report = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(report.status, "warn");
         assert_eq!(report.summary.manifest_count, 3);
         assert_eq!(report.summary.verified_blob_count, 2);
@@ -65622,7 +65651,7 @@ paths = ["~/.claude/projects"]
             raw_mirror_test_manifest(&data_dir, "codex", "local", &source_path, bytes, Vec::new());
         write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
 
-        let report = collect_doctor_raw_mirror_report_with_threshold(&data_dir, 1);
+        let report = collect_doctor_raw_mirror_report_with_threshold(&data_dir, 1, true);
 
         assert_eq!(report.status, "warn");
         assert_eq!(report.summary.total_blob_bytes, bytes.len() as u64);
@@ -65649,7 +65678,7 @@ paths = ["~/.claude/projects"]
         std::os::unix::fs::symlink(&outside_target, manifest_dir.join("linked.json"))
             .expect("create manifest symlink");
 
-        let report = collect_doctor_raw_mirror_report(&data_dir);
+        let report = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(report.status, "warn");
         assert_eq!(report.summary.manifest_count, 1);
         assert_eq!(report.summary.invalid_manifest_count, 1);
@@ -65696,7 +65725,7 @@ paths = ["~/.claude/projects"]
         )
         .expect("write raw mirror manifest");
 
-        let report = collect_doctor_raw_mirror_report(&data_dir);
+        let report = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(report.status, "warn");
         assert_eq!(report.summary.manifest_count, 1);
         assert_eq!(report.summary.invalid_manifest_count, 1);
@@ -65739,7 +65768,7 @@ paths = ["~/.claude/projects"]
         )
         .expect("write raw mirror manifest without blob");
 
-        let report = collect_doctor_raw_mirror_report(&data_dir);
+        let report = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(report.status, "warn");
         assert_eq!(report.summary.manifest_count, 1);
         assert_eq!(report.summary.missing_blob_count, 1);
@@ -65751,6 +65780,90 @@ paths = ["~/.claude/projects"]
         assert_eq!(
             report.manifests[0].blob_checksum_status,
             DoctorArtifactChecksumStatus::Missing
+        );
+    }
+
+    #[test]
+    fn raw_mirror_report_size_only_verification_skips_blake3_when_not_full() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let data_dir = temp.path().join("cass-data");
+        let source_path = data_dir.join("sessions/source.jsonl");
+        let bytes = b"{\"type\":\"message\",\"text\":\"size only\"}\n";
+        let manifest =
+            raw_mirror_test_manifest(&data_dir, "codex", "local", &source_path, bytes, Vec::new());
+        write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
+
+        let full_report = collect_doctor_raw_mirror_report(&data_dir, true);
+        assert_eq!(full_report.status, "verified");
+        assert_eq!(full_report.manifests[0].status, "verified");
+        assert_eq!(
+            full_report.manifests[0].blob_checksum_status,
+            DoctorArtifactChecksumStatus::Matched
+        );
+
+        let light_report = collect_doctor_raw_mirror_report(&data_dir, false);
+        assert_eq!(light_report.manifests[0].status, "size_verified");
+        assert_eq!(
+            light_report.manifests[0].blob_checksum_status,
+            DoctorArtifactChecksumStatus::NotRecorded,
+            "size-only verification should not claim content hash was checked"
+        );
+        assert_eq!(light_report.summary.manifest_count, 1);
+    }
+
+    #[test]
+    fn raw_mirror_report_size_only_detects_size_mismatch_without_full() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let data_dir = temp.path().join("cass-data");
+        let source_path = data_dir.join("sessions/source.jsonl");
+        let bytes = b"{\"type\":\"message\",\"text\":\"original\"}\n";
+        let manifest =
+            raw_mirror_test_manifest(&data_dir, "codex", "local", &source_path, bytes, Vec::new());
+        let (blob_path, _) = write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
+
+        std::fs::write(&blob_path, b"wrong size content that differs in length from original")
+            .expect("overwrite blob with wrong-size content");
+
+        let report = collect_doctor_raw_mirror_report(&data_dir, false);
+        assert_eq!(report.manifests[0].status, "size_mismatch");
+        assert_eq!(
+            report.manifests[0].blob_checksum_status,
+            DoctorArtifactChecksumStatus::Mismatched
+        );
+        assert!(
+            report.manifests[0]
+                .invalid_reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("--full"),
+            "size mismatch hint should mention --full for deeper verification"
+        );
+    }
+
+    #[test]
+    fn raw_mirror_report_size_only_passes_when_content_differs_but_size_matches() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let data_dir = temp.path().join("cass-data");
+        let source_path = data_dir.join("sessions/source.jsonl");
+        let bytes = b"original-content-here!!";
+        let manifest =
+            raw_mirror_test_manifest(&data_dir, "codex", "local", &source_path, bytes, Vec::new());
+        let (blob_path, _) = write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
+
+        let corrupted = b"corrupted-content-too!!";
+        assert_eq!(bytes.len(), corrupted.len(), "test requires same-length content");
+        std::fs::write(&blob_path, corrupted).expect("overwrite blob with same-size content");
+
+        let light_report = collect_doctor_raw_mirror_report(&data_dir, false);
+        assert_eq!(
+            light_report.manifests[0].status, "size_verified",
+            "size-only mode cannot detect same-size content corruption"
+        );
+
+        let full_report = collect_doctor_raw_mirror_report(&data_dir, true);
+        assert_eq!(
+            full_report.manifests[0].status, "checksum_mismatch",
+            "full mode catches content corruption that size-only misses"
         );
     }
 
@@ -65889,7 +66002,7 @@ paths = ["~/.claude/projects"]
         manifest.manifest_blake3 = None;
         write_raw_mirror_test_manifest(&data_dir, &manifest, bytes);
 
-        let before_raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let before_raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         let context =
             build_doctor_archive_scan_context(&data_dir, &data_dir.join("agent_search.db"));
         let mut plan = build_doctor_archive_normalize_plan(
@@ -65915,7 +66028,7 @@ paths = ["~/.claude/projects"]
             "annotation should be written additively"
         );
 
-        let after_raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        let after_raw_mirror = collect_doctor_raw_mirror_report(&data_dir, true);
         assert_eq!(
             before_raw_mirror.summary.manifest_count,
             after_raw_mirror.summary.manifest_count
@@ -70475,6 +70588,7 @@ fn wait_with_progress<T>(
         let mut last_phase = usize::MAX;
         let mut last_current = usize::MAX;
         let mut last_agents = usize::MAX;
+        let mut last_semantic_current = usize::MAX;
         let mut last_update = Instant::now();
 
         loop {
@@ -70487,6 +70601,8 @@ fn wait_with_progress<T>(
             let current = progress.current.load(Ordering::Relaxed);
             let agents = progress.discovered_agents.load(Ordering::Relaxed);
             let is_rebuilding = progress.is_rebuilding.load(Ordering::Relaxed);
+            let semantic_current = progress.semantic_current.load(Ordering::Relaxed);
+            let semantic_total = progress.semantic_total.load(Ordering::Relaxed);
 
             let agent_names: Vec<String> = progress
                 .discovered_agent_names
@@ -70497,6 +70613,7 @@ fn wait_with_progress<T>(
             let phase_str = match phase {
                 1 => "Scanning",
                 2 => "Indexing",
+                3 => "Embedding",
                 _ => "Preparing",
             };
 
@@ -70538,6 +70655,16 @@ fn wait_with_progress<T>(
                 } else {
                     format!("{}{}: Processing...", phase_str, rebuild_indicator)
                 }
+            } else if phase == 3 {
+                if semantic_total > 0 {
+                    let pct = (semantic_current as f64 / semantic_total as f64 * 100.0).min(100.0);
+                    format!(
+                        "{}{}: {}/{} messages ({:.0}%)",
+                        phase_str, rebuild_indicator, semantic_current, semantic_total, pct
+                    )
+                } else {
+                    format!("{}{}: preparing...", phase_str, rebuild_indicator)
+                }
             } else {
                 format!("{}{}...", phase_str, rebuild_indicator)
             };
@@ -70546,6 +70673,7 @@ fn wait_with_progress<T>(
             let should_update = phase != last_phase
                 || current != last_current
                 || agents != last_agents
+                || semantic_current != last_semantic_current
                 || now.duration_since(last_update).as_millis() > 500;
 
             if should_update {
@@ -70553,6 +70681,7 @@ fn wait_with_progress<T>(
                 last_phase = phase;
                 last_current = current;
                 last_agents = agents;
+                last_semantic_current = semantic_current;
                 last_update = now;
             }
 
@@ -70569,6 +70698,7 @@ fn wait_with_progress<T>(
         let mut last_agents = 0;
         let mut last_current = 0;
         let mut last_scan_current = 0;
+        let mut last_semantic_current = 0;
 
         loop {
             if handle.is_finished() {
@@ -70579,11 +70709,14 @@ fn wait_with_progress<T>(
             let total = progress.total.load(Ordering::Relaxed);
             let current = progress.current.load(Ordering::Relaxed);
             let agents = progress.discovered_agents.load(Ordering::Relaxed);
+            let semantic_current = progress.semantic_current.load(Ordering::Relaxed);
+            let semantic_total = progress.semantic_total.load(Ordering::Relaxed);
 
             if phase != last_phase {
                 match phase {
                     1 => eprintln!("Scanning for agents..."),
                     2 => eprintln!("Indexing conversations..."),
+                    3 => eprintln!("Embedding messages..."),
                     _ => {}
                 }
                 last_phase = phase;
@@ -70610,6 +70743,18 @@ fn wait_with_progress<T>(
                     eprintln!("  Indexed {} conversations", current);
                 }
                 last_current = current;
+            }
+
+            if phase == 3
+                && semantic_current > last_semantic_current
+                && (semantic_current.is_multiple_of(100) || semantic_current == semantic_total)
+            {
+                if semantic_total > 0 {
+                    eprintln!("  Embedded {}/{} messages", semantic_current, semantic_total);
+                } else {
+                    eprintln!("  Embedded {} messages", semantic_current);
+                }
+                last_semantic_current = semantic_current;
             }
 
             std::thread::sleep(Duration::from_millis(200));
@@ -72907,6 +73052,7 @@ pub(crate) fn run_doctor_impl(
     command_surface: doctor::DoctorCommandSurface,
     execution_mode: doctor::DoctorExecutionMode,
     requested_plan_fingerprint: Option<String>,
+    full: bool,
     wrap: WrapConfig,
 ) -> CliResult<()> {
     use colored::*;
@@ -73769,7 +73915,7 @@ pub(crate) fn run_doctor_impl(
     }
 
     let raw_mirror_scan_started = Instant::now();
-    let mut raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+    let mut raw_mirror = collect_doctor_raw_mirror_report(&data_dir, full);
     doctor_push_timing_span(
         &mut timing_spans,
         "raw_mirror_scan",
@@ -73793,7 +73939,7 @@ pub(crate) fn run_doctor_impl(
             raw_mirror_backfill.captured_live_source_count,
             raw_mirror_backfill.existing_raw_manifest_link_count
         ));
-        raw_mirror = collect_doctor_raw_mirror_report(&data_dir);
+        raw_mirror = collect_doctor_raw_mirror_report(&data_dir, full);
     }
     doctor_push_timing_span(
         &mut timing_spans,
@@ -84438,10 +84584,19 @@ fn refresh_index_inline(db_override: Option<PathBuf>, data_dir_override: Option<
         let phase = progress.phase.load(Ordering::Relaxed);
         let current = progress.current.load(Ordering::Relaxed);
         let total = progress.total.load(Ordering::Relaxed);
+        let (current, total) = if phase == 3 {
+            (
+                progress.semantic_current.load(Ordering::Relaxed),
+                progress.semantic_total.load(Ordering::Relaxed),
+            )
+        } else {
+            (current, total)
+        };
         if phase != last_phase || current != last_current || total != last_total {
             let phase_str = match phase {
                 1 => "scanning",
                 2 => "indexing",
+                3 => "embedding",
                 _ => "preparing",
             };
             if total > 0 {
@@ -84462,12 +84617,21 @@ fn refresh_index_inline(db_override: Option<PathBuf>, data_dir_override: Option<
     let final_phase = progress.phase.load(Ordering::Relaxed);
     let final_current = progress.current.load(Ordering::Relaxed);
     let final_total = progress.total.load(Ordering::Relaxed);
+    let (final_current, final_total) = if final_phase == 3 {
+        (
+            progress.semantic_current.load(Ordering::Relaxed),
+            progress.semantic_total.load(Ordering::Relaxed),
+        )
+    } else {
+        (final_current, final_total)
+    };
     if (final_phase != last_phase || final_current != last_current || final_total != last_total)
         && final_total > 0
     {
         let phase_str = match final_phase {
             1 => "scanning",
             2 => "indexing",
+            3 => "embedding",
             _ => "preparing",
         };
         eprintln!("  {phase_str}: {final_current}/{final_total}");
@@ -84789,9 +84953,15 @@ impl IndexStallWatchdog {
         let phase_code = index_progress
             .phase
             .load(std::sync::atomic::Ordering::Relaxed);
-        let current = index_progress
-            .current
-            .load(std::sync::atomic::Ordering::Relaxed);
+        let current = if phase_code == 3 {
+            index_progress
+                .semantic_current
+                .load(std::sync::atomic::Ordering::Relaxed)
+        } else {
+            index_progress
+                .current
+                .load(std::sync::atomic::Ordering::Relaxed)
+        };
 
         if phase_code != self.last_phase {
             self.last_phase = phase_code;
@@ -85691,6 +85861,7 @@ fn run_index_with_data(
         let mut last_phase = usize::MAX;
         let mut last_current = usize::MAX;
         let mut last_agents = usize::MAX;
+        let mut last_semantic_current = usize::MAX;
         let mut last_update = std::time::Instant::now();
         let mut stall_watchdog =
             IndexStallWatchdog::aborting_phase_two(data_dir.clone(), progress_interval)
@@ -85708,6 +85879,8 @@ fn run_index_with_data(
             let current = index_progress.current.load(Ordering::Relaxed);
             let agents = index_progress.discovered_agents.load(Ordering::Relaxed);
             let is_rebuilding = index_progress.is_rebuilding.load(Ordering::Relaxed);
+            let semantic_current = index_progress.semantic_current.load(Ordering::Relaxed);
+            let semantic_total = index_progress.semantic_total.load(Ordering::Relaxed);
 
             // Get agent names for display
             let agent_names: Vec<String> = index_progress
@@ -85719,6 +85892,7 @@ fn run_index_with_data(
             let phase_str = match phase {
                 1 => "Scanning",
                 2 => "Indexing",
+                3 => "Embedding",
                 _ => "Preparing",
             };
 
@@ -85761,6 +85935,17 @@ fn run_index_with_data(
                 } else {
                     format!("{}{}: Processing...", phase_str, rebuild_indicator)
                 }
+            } else if phase == 3 {
+                // Embedding phase - show progress
+                if semantic_total > 0 {
+                    let pct = (semantic_current as f64 / semantic_total as f64 * 100.0).min(100.0);
+                    format!(
+                        "{}{}: {}/{} messages ({:.0}%)",
+                        phase_str, rebuild_indicator, semantic_current, semantic_total, pct
+                    )
+                } else {
+                    format!("{}{}: preparing...", phase_str, rebuild_indicator)
+                }
             } else {
                 format!("{}{}...", phase_str, rebuild_indicator)
             };
@@ -85770,6 +85955,7 @@ fn run_index_with_data(
             let should_update = phase != last_phase
                 || current != last_current
                 || agents != last_agents
+                || semantic_current != last_semantic_current
                 || now.duration_since(last_update).as_millis() > 500;
 
             if should_update {
@@ -85777,6 +85963,7 @@ fn run_index_with_data(
                 last_phase = phase;
                 last_current = current;
                 last_agents = agents;
+                last_semantic_current = semantic_current;
                 last_update = now;
             }
 
@@ -85806,6 +85993,7 @@ fn run_index_with_data(
         let mut last_agents = 0;
         let mut last_current = 0;
         let mut last_scan_current = 0;
+        let mut last_semantic_current = 0;
         let mut stall_watchdog =
             IndexStallWatchdog::aborting_phase_two(data_dir.clone(), progress_interval)
                 .watch_aware(watch)
@@ -85820,12 +86008,15 @@ fn run_index_with_data(
             let total = index_progress.total.load(Ordering::Relaxed);
             let current = index_progress.current.load(Ordering::Relaxed);
             let agents = index_progress.discovered_agents.load(Ordering::Relaxed);
+            let semantic_current = index_progress.semantic_current.load(Ordering::Relaxed);
+            let semantic_total = index_progress.semantic_total.load(Ordering::Relaxed);
 
             // Print status on phase change
             if phase != last_phase {
                 match phase {
                     1 => eprintln!("Scanning for agents..."),
                     2 => eprintln!("Indexing conversations..."),
+                    3 => eprintln!("Embedding messages..."),
                     _ => {}
                 }
                 last_phase = phase;
@@ -85855,6 +86046,19 @@ fn run_index_with_data(
                     eprintln!("  Indexed {} conversations", current);
                 }
                 last_current = current;
+            }
+
+            // Print embedding progress every 100 messages
+            if phase == 3
+                && semantic_current > last_semantic_current
+                && semantic_current % 100 == 0
+            {
+                if semantic_total > 0 {
+                    eprintln!("  Embedded {}/{} messages", semantic_current, semantic_total);
+                } else {
+                    eprintln!("  Embedded {} messages", semantic_current);
+                }
+                last_semantic_current = semantic_current;
             }
 
             if let Some(payload) =
@@ -95808,6 +96012,7 @@ fn run_models_command(cmd: ModelsCommand, cli: &Cli) -> CliResult<()> {
             from_file,
             yes,
             data_dir,
+            json: _,
         } => run_models_install(
             &model,
             mirror.as_deref(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37389,7 +37389,11 @@ fn collect_doctor_raw_mirror_report_with_threshold(
             *blob_reference_counts
                 .entry(manifest.blob_blake3.clone())
                 .or_default() += 1;
-            if manifest.blob_checksum_status == DoctorArtifactChecksumStatus::Matched {
+            if matches!(
+                manifest.blob_checksum_status,
+                DoctorArtifactChecksumStatus::Matched
+                    | DoctorArtifactChecksumStatus::NotRecorded
+            ) {
                 verified_blob_bytes
                     .entry(manifest.blob_blake3.clone())
                     .or_insert(manifest.blob_size_bytes);

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -7527,7 +7527,7 @@ impl SearchClient {
         let mut sql = format!(
             "SELECT c.id, {title_expr}, m.content, \
                  COALESCE((SELECT a.slug FROM agents a WHERE a.id = c.agent_id), 'unknown'), \
-                 w.path, c.source_path, m.created_at, m.idx, \
+                 w.path, c.source_path, COALESCE(m.created_at, c.started_at), m.idx, \
                  {normalized_source_sql}, c.origin_host, s.kind
              FROM messages m
              JOIN conversations c ON m.conversation_id = c.id
@@ -7556,11 +7556,11 @@ impl SearchClient {
         }
 
         if let Some(created_from) = filters.created_from {
-            sql.push_str(" AND m.created_at >= ?");
+            sql.push_str(" AND COALESCE(m.created_at, c.started_at) >= ?");
             params.push(ParamValue::from(created_from));
         }
         if let Some(created_to) = filters.created_to {
-            sql.push_str(" AND m.created_at <= ?");
+            sql.push_str(" AND COALESCE(m.created_at, c.started_at) <= ?");
             params.push(ParamValue::from(created_to));
         }
 
@@ -7582,7 +7582,7 @@ impl SearchClient {
         }
 
         sql.push_str(&format!(
-            " ORDER BY CASE WHEN m.created_at IS NULL THEN 1 ELSE 0 END, m.created_at {order}, m.id {order} LIMIT ? OFFSET ?"
+            " ORDER BY CASE WHEN COALESCE(m.created_at, c.started_at) IS NULL THEN 1 ELSE 0 END, COALESCE(m.created_at, c.started_at) {order}, m.id {order} LIMIT ? OFFSET ?"
         ));
         params.push(ParamValue::from(limit as i64));
         params.push(ParamValue::from(offset as i64));
@@ -12460,7 +12460,8 @@ mod tests {
                 source_id TEXT,
                 origin_host TEXT,
                 title TEXT,
-                source_path TEXT NOT NULL
+                source_path TEXT NOT NULL,
+                started_at INTEGER
              );
              CREATE TABLE workspaces (id INTEGER PRIMARY KEY, path TEXT NOT NULL);
              CREATE TABLE messages (
@@ -12474,8 +12475,8 @@ mod tests {
         )?;
         conn.execute("INSERT INTO agents(id, slug) VALUES(1, 'codex')")?;
         conn.execute(
-            "INSERT INTO conversations(id, agent_id, workspace_id, source_id, origin_host, title, source_path)
-             VALUES(1, 1, NULL, NULL, NULL, 'browse title', '/tmp/browse.jsonl')",
+            "INSERT INTO conversations(id, agent_id, workspace_id, source_id, origin_host, title, source_path, started_at)
+             VALUES(1, 1, NULL, NULL, NULL, 'browse title', '/tmp/browse.jsonl', NULL)",
         )?;
         conn.execute(
             "INSERT INTO messages(id, conversation_id, idx, content, created_at)
@@ -12514,6 +12515,100 @@ mod tests {
         assert_eq!(hits[0].workspace, "");
         assert_eq!(hits[0].source_id, "local");
         assert_eq!(hits[0].origin_kind, "local");
+
+        Ok(())
+    }
+
+    #[test]
+    fn browse_by_date_falls_back_to_conversation_started_at() -> Result<()> {
+        let conn = Connection::open(":memory:")?;
+        conn.execute_batch(
+            "CREATE TABLE agents (id INTEGER PRIMARY KEY, slug TEXT NOT NULL);
+             CREATE TABLE conversations (
+                id INTEGER PRIMARY KEY,
+                agent_id INTEGER NOT NULL,
+                workspace_id INTEGER,
+                source_id TEXT,
+                origin_host TEXT,
+                title TEXT,
+                source_path TEXT NOT NULL,
+                started_at INTEGER
+             );
+             CREATE TABLE workspaces (id INTEGER PRIMARY KEY, path TEXT NOT NULL);
+             CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                conversation_id INTEGER NOT NULL,
+                idx INTEGER,
+                content TEXT NOT NULL,
+                created_at INTEGER
+             );
+             CREATE TABLE sources (id TEXT PRIMARY KEY, kind TEXT);",
+        )?;
+        conn.execute("INSERT INTO agents(id, slug) VALUES(1, 'codex')")?;
+        conn.execute(
+            "INSERT INTO conversations(id, agent_id, workspace_id, source_id, origin_host, title, source_path, started_at)
+             VALUES(1, 1, NULL, NULL, NULL, 'conv with started_at', '/tmp/fallback.jsonl', 500)",
+        )?;
+        conn.execute(
+            "INSERT INTO messages(id, conversation_id, idx, content, created_at)
+             VALUES(1, 1, 0, 'message with null created_at', NULL)",
+        )?;
+
+        let client = SearchClient {
+            reader: None,
+            sqlite: Mutex::new(Some(SendConnection(conn))),
+            sqlite_path: None,
+            prefix_cache: Mutex::new(CacheShards::new(*CACHE_TOTAL_CAP, *CACHE_BYTE_CAP)),
+            reload_on_search: true,
+            last_reload: Mutex::new(None),
+            last_generation: Mutex::new(None),
+            reload_epoch: Arc::new(AtomicU64::new(0)),
+            warm_tx: None,
+            _warm_handle: None,
+            metrics: Metrics::default(),
+            cache_namespace: format!("v{CACHE_KEY_VERSION}|schema:test"),
+            semantic: Mutex::new(None),
+            last_tantivy_total_count: Mutex::new(None),
+        };
+
+        // Unfiltered: message should appear with conversation's started_at as its timestamp
+        let hits = client.browse_by_date(
+            SearchFilters::default(),
+            5,
+            0,
+            true,
+            FieldMask::FULL,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].created_at, Some(500), "should display conversation started_at");
+
+        // Date-range filter: should include the message when the range covers started_at
+        let hits = client.browse_by_date(
+            SearchFilters {
+                created_from: Some(400),
+                created_to: Some(600),
+                ..SearchFilters::default()
+            },
+            5,
+            0,
+            true,
+            FieldMask::FULL,
+        )?;
+        assert_eq!(hits.len(), 1, "should be included when range covers conversation started_at");
+
+        // Date-range filter: should exclude when range misses started_at
+        let hits = client.browse_by_date(
+            SearchFilters {
+                created_from: Some(600),
+                created_to: Some(700),
+                ..SearchFilters::default()
+            },
+            5,
+            0,
+            true,
+            FieldMask::FULL,
+        )?;
+        assert_eq!(hits.len(), 0, "should be excluded when range misses conversation started_at");
 
         Ok(())
     }
@@ -13409,7 +13504,8 @@ mod tests {
                 source_id TEXT,
                 origin_host TEXT,
                 title TEXT,
-                source_path TEXT NOT NULL
+                source_path TEXT NOT NULL,
+                started_at INTEGER
              );
              CREATE TABLE workspaces (id INTEGER PRIMARY KEY, path TEXT NOT NULL);
              CREATE TABLE messages (
@@ -13423,8 +13519,8 @@ mod tests {
         )?;
         conn.execute("INSERT INTO agents(id, slug) VALUES(1, 'codex')")?;
         conn.execute(
-            "INSERT INTO conversations(id, agent_id, workspace_id, source_id, origin_host, title, source_path)
-             VALUES(1, 1, NULL, 'local', NULL, 'browse title', '/tmp/browse-shared.jsonl')",
+            "INSERT INTO conversations(id, agent_id, workspace_id, source_id, origin_host, title, source_path, started_at)
+             VALUES(1, 1, NULL, 'local', NULL, 'browse title', '/tmp/browse-shared.jsonl', NULL)",
         )?;
         let shared_prefix = "shared-prefix ".repeat(48);
         let first = format!("{shared_prefix}first browse-only tail");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -305,20 +305,27 @@ impl LoadingContext {
 /// Snapshot of indexer progress atomics, polled each tick.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct IndexProgressSnapshot {
-    /// 0=Idle, 1=Scanning, 2=Indexing
+    /// 0=Idle, 1=Scanning, 2=Indexing, 3=Embedding
     phase: usize,
     current: usize,
     total: usize,
     _is_rebuilding: bool,
     agents_discovered: usize,
+    semantic_current: usize,
+    semantic_total: usize,
 }
 
 impl IndexProgressSnapshot {
     fn ratio(&self) -> f64 {
-        if self.total == 0 {
+        let (current, total) = if self.phase == 3 {
+            (self.semantic_current, self.semantic_total)
+        } else {
+            (self.current, self.total)
+        };
+        if total == 0 {
             0.0
         } else {
-            (self.current as f64 / self.total as f64).clamp(0.0, 1.0)
+            (current as f64 / total as f64).clamp(0.0, 1.0)
         }
     }
 
@@ -326,6 +333,7 @@ impl IndexProgressSnapshot {
         match self.phase {
             1 => "Scanning",
             2 => "Indexing",
+            3 => "Embedding",
             _ => "Idle",
         }
     }
@@ -7934,6 +7942,21 @@ impl CassApp {
                         "Indexing {}/{} ({}%)",
                         snap.current,
                         snap.total,
+                        (r * 100.0) as u32
+                    );
+                    FtuiProgressBar::new()
+                        .ratio(r)
+                        .label(&label)
+                        .style(bg_style)
+                        .gauge_style(gauge_style)
+                        .render(area, frame);
+                } else if snap.phase == 3 && snap.semantic_total > 0 {
+                    // Determinate: show "Embedding 42/100 (42%)"
+                    let r = snap.ratio();
+                    let label = format!(
+                        "Embedding {}/{} ({}%)",
+                        snap.semantic_current,
+                        snap.semantic_total,
                         (r * 100.0) as u32
                     );
                     FtuiProgressBar::new()
@@ -19736,6 +19759,8 @@ impl super::ftui_adapter::Model for CassApp {
                         total: progress.total.load(Relaxed),
                         _is_rebuilding: progress.is_rebuilding.load(Relaxed),
                         agents_discovered: progress.discovered_agents.load(Relaxed),
+                        semantic_current: progress.semantic_current.load(Relaxed),
+                        semantic_total: progress.semantic_total.load(Relaxed),
                     };
                     let snap = &self.index_progress_snapshot;
                     self.status = if snap.phase == 2 && snap.total > 0 {
@@ -19747,6 +19772,13 @@ impl super::ftui_adapter::Model for CassApp {
                         )
                     } else if snap.phase == 1 {
                         format!("Scanning... ({} agents found)", snap.agents_discovered)
+                    } else if snap.phase == 3 && snap.semantic_total > 0 {
+                        format!(
+                            "Embedding {}/{} ({}%)",
+                            snap.semantic_current,
+                            snap.semantic_total,
+                            (snap.ratio() * 100.0) as u32
+                        )
                     } else {
                         "Refreshing index...".to_string()
                     };

--- a/tests/cli_model_lifecycle_contract.rs
+++ b/tests/cli_model_lifecycle_contract.rs
@@ -43,7 +43,7 @@ fn models_install_from_file_keeps_acquisition_data_dir_scoped() -> Result<(), St
                 mirror: None,
                 from_file: Some(from_file),
                 yes: true,
-                data_dir: Some(data_dir),
+                data_dir: Some(data_dir), json: _,
             })) if model == "all-minilm-l6-v2"
                 && from_file.display().to_string() == "/seeded/models/all-minilm-l6-v2"
                 && data_dir.display().to_string() == "/cass/models" =>
@@ -79,7 +79,7 @@ fn models_install_from_mirror_keeps_acquisition_data_dir_scoped() -> Result<(), 
                 mirror: Some(mirror),
                 from_file: None,
                 yes: true,
-                data_dir: Some(data_dir),
+                data_dir: Some(data_dir), json: _,
             })) if model == "all-minilm-l6-v2"
                 && mirror == "https://mirror.example/models"
                 && data_dir.display().to_string() == "/cass/models" =>
@@ -133,7 +133,7 @@ fn models_install_defaults_to_standard_model_with_confirmation() -> Result<(), S
                 mirror: None,
                 from_file: None,
                 yes: false,
-                data_dir: Some(data_dir),
+                data_dir: Some(data_dir), json: _,
             })) if model == "all-minilm-l6-v2"
                 && data_dir.display().to_string() == "/cass/models" =>
             {

--- a/tests/cli_refresh_contract.rs
+++ b/tests/cli_refresh_contract.rs
@@ -295,6 +295,7 @@ fn raw_mirror_and_doctor_modules_are_public_embedding_surfaces() -> Result<(), S
         false,
         false,
         false,
+        false,
     )
     .map_err(|err| format!("build public doctor check request: {err}"))?;
     assert_eq!(doctor_request.surface, DoctorCommandSurface::Check);


### PR DESCRIPTION
Hey — I know you generally don't accept outside PRs, so no pressure to merge this. I'm running a fork for my own use and wanted to surface these fixes in case any are useful to you. Happy to close this if you'd prefer issues instead (or nothing at all).

### What's in here

**1. Embedding progress is invisible during `cass index --semantic`**

The CLI spinner shows "Scanning 22/22 connectors" for the entire duration of semantic embedding because the UI phase never advances past scanning. The `SemanticProgressSink` and per-batch counters already exist but are wired to a no-op. This adds phase 3 ("Embedding") to `IndexingProgress` with `semantic_current`/`semantic_total` atomics, and renders live progress ("Embedding: 12000/47118 messages (25%)") in the CLI spinner, plain-mode output, and TUI.

**2. Stall watchdog kills semantic embedding**

Related to the above — the stall watchdog only checks the `current` atomic for progress, which is frozen during embedding (only `semantic_current` advances). This causes the watchdog to detect a false stall and abort. The existing `semantic_build` flag + phase-0 carve-out was the workaround, but with phase 3 in place, the fix is simpler: read `semantic_current` instead of `current` when `phase_code == 3`.

**3. `cass doctor` is unusable on large histories**

`doctor_verify_raw_mirror_manifest` re-hashes every raw-mirror blob via blake3 on every run — full file read + CPU hash per blob, unconditionally. On machines with large session histories this makes `cass doctor` hang indefinitely. This adds a `--full` flag: without it, raw mirror verification uses size-only checks. Exhaustive blake3 verification is opt-in via `--full`. Non-doctor callers (forensic bundle, archive scan, baseline) retain full verification. Includes 3 tests covering the size-only path.

**4. `cass models install --json` errors**

The `Install` variant of `ModelsCommand` is missing the `json` flag that its siblings (`Status`, `Verify`, `Backfill`) have. The robot-safe command templates in `model_acquisition.rs` generate `cass models install --model <name> --json`, which fails at the CLI parser. Added the flag to match sibling subcommands.