### PR TITLE
fix(indexer): size-gate the O(database-size) pre-rebuild quick_check integrity preflight

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -15990,11 +15990,16 @@ fn full_rebuild_existing_storage_integrity_problem(
     // large archive, blocks the pre-index phase for minutes with no progress
     // signal (see `integrity_preflight_full_check_max_bytes`). Size-gate it: run
     // the full walk only for archives at or below the threshold, and otherwise
-    // rely on the per-table canaries that follow.
+    // rely on the per-table canaries that follow. Measure the whole archive
+    // bundle (main db + `-wal`/`-shm`) via `database_bundle_size_bytes`, not the
+    // main file alone: indexing deliberately runs with large deferred-checkpoint
+    // WALs, and quick_check walks the merged main+WAL view, so a WAL-heavy
+    // archive with a small main file must not slip under the gate and hit the
+    // exact stall this guards against.
     let db_bytes = storage
         .database_path()
         .ok()
-        .map(|path| file_size_bytes(&path))
+        .map(|path| database_bundle_size_bytes(&path))
         .unwrap_or(0);
     let max_bytes = integrity_preflight_full_check_max_bytes();
     if integrity_preflight_should_run_full_check(db_bytes, max_bytes) {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -15953,25 +15953,77 @@ fn anyhow_chain_indicates_retryable_storage_contention(err: &anyhow::Error) -> b
         .any(|cause| crate::storage::sqlite::retryable_storage_error_message(&cause.to_string()))
 }
 
+/// Maximum canonical-archive size (in bytes) for which the pre-rebuild
+/// `PRAGMA quick_check` integrity walk runs. That walk visits every b-tree page
+/// of the archive to validate page headers, cell pointers, and freeblock chains,
+/// so it is O(database size): on a multi-GB archive it takes many minutes
+/// (measured at >150s on both frankensqlite and stock SQLite 3.45 for an ~9GB
+/// store) and runs in the pre-index "preparing" phase with no progress
+/// heartbeat, which makes `cass index --full` look wedged for the whole walk
+/// (phase stays at 0 with current=0; the stall watchdog logs `stall_detected`
+/// but never aborts a phase-0 preflight). Above this bound cass skips the
+/// whole-database walk and relies on the per-table canaries below (which catch
+/// the "core tables unreadable" corruption that would actually break indexing);
+/// a full integrity scan stays available out-of-band via `cass doctor`.
+///
+/// Override with `CASS_INDEX_INTEGRITY_PREFLIGHT_MAX_BYTES` (`0` = always run
+/// the full walk regardless of size). Default: 2 GiB.
+fn integrity_preflight_full_check_max_bytes() -> u64 {
+    const DEFAULT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+    dotenvy::var("CASS_INDEX_INTEGRITY_PREFLIGHT_MAX_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_BYTES)
+}
+
+/// Whether the full `PRAGMA quick_check` walk should run for an archive of
+/// `db_bytes`, given the `max_bytes` gate. `max_bytes == 0` disables the gate
+/// (always walk); otherwise the walk runs only at or below the threshold.
+fn integrity_preflight_should_run_full_check(db_bytes: u64, max_bytes: u64) -> bool {
+    max_bytes == 0 || db_bytes <= max_bytes
+}
+
 fn full_rebuild_existing_storage_integrity_problem(
     storage: &FrankenStorage,
 ) -> Result<Option<String>> {
-    let quick_check = match storage.raw().query_row_map(
-        "PRAGMA quick_check(1)",
-        &[] as &[ParamValue],
-        |row| row.get_typed::<String>(0),
-    ) {
-        Ok(status) => status,
-        Err(err) if crate::storage::sqlite::retryable_franken_error(&err) => {
-            return Err(anyhow::anyhow!(
-                "full rebuild archive integrity preflight hit transient storage contention: {err}"
-            ));
-        }
-        Err(err) => return Ok(Some(format!("quick_check failed: {err}"))),
-    };
+    // The whole-database `PRAGMA quick_check` below is O(database size) and, on a
+    // large archive, blocks the pre-index phase for minutes with no progress
+    // signal (see `integrity_preflight_full_check_max_bytes`). Size-gate it: run
+    // the full walk only for archives at or below the threshold, and otherwise
+    // rely on the per-table canaries that follow.
+    let db_bytes = storage
+        .database_path()
+        .ok()
+        .map(|path| file_size_bytes(&path))
+        .unwrap_or(0);
+    let max_bytes = integrity_preflight_full_check_max_bytes();
+    if integrity_preflight_should_run_full_check(db_bytes, max_bytes) {
+        let quick_check = match storage.raw().query_row_map(
+            "PRAGMA quick_check(1)",
+            &[] as &[ParamValue],
+            |row| row.get_typed::<String>(0),
+        ) {
+            Ok(status) => status,
+            Err(err) if crate::storage::sqlite::retryable_franken_error(&err) => {
+                return Err(anyhow::anyhow!(
+                    "full rebuild archive integrity preflight hit transient storage contention: {err}"
+                ));
+            }
+            Err(err) => return Ok(Some(format!("quick_check failed: {err}"))),
+        };
 
-    if !quick_check.trim().eq_ignore_ascii_case("ok") {
-        return Ok(Some(format!("quick_check reported {quick_check:?}")));
+        if !quick_check.trim().eq_ignore_ascii_case("ok") {
+            return Ok(Some(format!("quick_check reported {quick_check:?}")));
+        }
+    } else {
+        tracing::warn!(
+            db_bytes,
+            max_bytes,
+            "skipping the whole-database PRAGMA quick_check integrity preflight for a large \
+             archive: the walk is O(database size) and would block indexing for minutes. \
+             Relying on per-table canaries. Run 'cass doctor check --json' for a full integrity \
+             scan, or set CASS_INDEX_INTEGRITY_PREFLIGHT_MAX_BYTES=0 to always run the full check."
+        );
     }
 
     for (table, sql) in [
@@ -40098,6 +40150,19 @@ mod tests {
                 "expected {falsy:?} to keep the headroom check enabled"
             );
         }
+    }
+
+    #[test]
+    fn integrity_preflight_size_gate_controls_full_quick_check() {
+        let gib = 1024_u64 * 1024 * 1024;
+        // max_bytes == 0 disables the gate: the full O(DB-size) walk always runs.
+        assert!(integrity_preflight_should_run_full_check(64 * gib, 0));
+        // At or below the threshold the full walk runs...
+        assert!(integrity_preflight_should_run_full_check(gib, 2 * gib));
+        assert!(integrity_preflight_should_run_full_check(2 * gib, 2 * gib));
+        // ...and above it the walk is skipped (the per-table canaries still run).
+        assert!(!integrity_preflight_should_run_full_check(2 * gib + 1, 2 * gib));
+        assert!(!integrity_preflight_should_run_full_check(9 * gib, 2 * gib));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`cass index --full` can hang for many minutes in the pre-index **"preparing"** phase on a large canonical archive, with no progress and no abort. The cause is the pre-rebuild integrity preflight: `full_rebuild_existing_storage_integrity_problem()` runs `PRAGMA quick_check(1)`, which walks **every b-tree page** of the archive. That is O(database size), so on a multi-GB store it dominates (or effectively blocks) startup before any indexing begins.

This PR size-gates that whole-database walk: above a configurable threshold (default **2 GiB**), cass skips the full `quick_check` and relies on the cheap per-table canaries the function already runs, with a full scan still available out-of-band via `cass doctor check`.

## Repro / diagnosis

On a 14.6 GB / 12,545-conversation canonical archive (Linux x86-64, `main` @ `047f70a`, binary reports `cass 0.6.22`):

- `cass index --full --json` sits in `{"phase":"preparing","phase_code":0,"current":0}` for **>360 s** and never advances. The stall watchdog logs `stall_detected` but never aborts, because a phase-0 preflight is not abort-eligible (`abort_eligible = phase_code == 2 || finalize_wedge`). So it is a silent hang, not a self-abort, and distinct from the post-publish "preparing" wedges (#297/#319 etc.).
- A symbolized backtrace during the hang:

  ```
  indexer::run_index
    -> full_rebuild_existing_storage_integrity_problem
    -> query_row_map ("PRAGMA quick_check(1)")
    -> validate_database_integrity -> with_integrity_txn
    -> validate_schema_btrees_in_txn -> walk_integrity_btree_pages (x4)
  ```

- The cost is **inherent to a whole-database integrity walk, not a frankensqlite regression**: stock `sqlite3` 3.45 `PRAGMA quick_check` on the *same* archive also exceeds 150 s (killed at the cap). So the fix is to not run an O(DB) scan before every rebuild, rather than to chase engine-specific slowness.

## Why gating is safe

`full_rebuild_existing_storage_integrity_problem()` already runs cheap per-table canaries after the walk (`SELECT COUNT(*)` on `conversations` / `messages` / `sources`). Those catch the "core tables unreadable / schema broken" corruption that would actually break indexing, which is the failure mode the preflight guards against before a rebuild. The exhaustive page-level walk is disproportionate to run on every index of a large archive, and a full integrity scan remains available on demand via `cass doctor check`.

## Change

- New `integrity_preflight_full_check_max_bytes()` reads `CASS_INDEX_INTEGRITY_PREFLIGHT_MAX_BYTES` (default `2 * 1024^3`; `0` = always run the full walk).
- New pure `integrity_preflight_should_run_full_check(db_bytes, max_bytes)` decides the gate.
- `full_rebuild_existing_storage_integrity_problem()` measures the archive via `storage.database_path()` + `file_size_bytes()`; above the bound it skips the walk with a `tracing::warn!` (pointing at `cass doctor check` and the env override) and falls through to the canaries. If the size cannot be determined it defaults to running the full walk (fail-safe).
- Regression test `integrity_preflight_size_gate_controls_full_quick_check` covers the boundary and the `0`-disables case.

## Verification

Built from this branch and run against the same 14.6 GB archive:

- The preflight now skips in ~40 ms and the pipeline proceeds into real indexing (daily_stats + lexical rebuild of the 12,545 conversations), where before it never got past the walk:

  ```
  WARN skipping the whole-database PRAGMA quick_check integrity preflight for a large archive ...
       db_bytes=15748939776 max_bytes=2147483648
  WARN daily_stats is missing or drifted; rebuilding from canonical conversations ... conversation_count=12545
  WARN lexical rebuild conversation content exceeded the per-conversation cap; truncated ... conversation_id=5033 ...
  ```

- `cargo test integrity_preflight_size_gate_controls_full_quick_check` passes.

## Scope note

This PR fixes the **pre-index integrity preflight** hang specifically. Once the preflight is out of the way, a full rebuild of a very large archive exercises the separate downstream large-DB paths, which I also hit on the 14.6 GB corpus and which are independent of this change:

- `daily_stats` rebuild OOM → bounded fallback (#239),
- per-conversation content caps during lexical rebuild (#290, cited in the code's own warning),
- and a `lexical_refresh` rebuild that then stalled with no forward progress (the stall diagnostic points at #244 / #258).

So on that corpus `cass index --full` does not run fully to completion even with this change; those downstream wedges are pre-existing and tracked separately. I deliberately kept this fix narrow and focused on the preflight rather than bundling unrelated large-DB work.

Happy to adjust the default threshold or the gating approach (e.g. opt-in vs. default-on) to match your preference.
