### PR TITLE
fix(semantic): reconcile mutable watch-once prefixes

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -15312,6 +15312,7 @@ struct SemanticContentFingerprint {
 enum TargetedSemanticWatchOnceMode {
     RebuildAll,
     AppendToExisting,
+    ReconcileExisting,
     AlreadyCovered,
 }
 
@@ -15325,6 +15326,7 @@ struct TargetedSemanticWatchOnceSelection {
     total_conversations: u64,
     current_db_fingerprint: String,
     manifest_before_db_fingerprint: Option<String>,
+    current_message_ids: Option<HashSet<u64>>,
     reason: &'static str,
 }
 
@@ -15457,6 +15459,52 @@ fn semantic_artifact_is_append_only_prefix(
     Ok(observed_prefix_conversations.eq(&artifact_fingerprint.total_conversations))
 }
 
+fn current_semantic_message_ids(storage: &FrankenStorage) -> Result<HashSet<u64>> {
+    let raw_message_ids: Vec<i64> = storage
+        .raw()
+        .query_map_collect(
+            "SELECT m.id
+             FROM messages AS m
+             INNER JOIN conversations AS c ON c.id = m.conversation_id",
+            &[],
+            |row| row.get_typed(0),
+        )
+        .context("loading current canonical message ids for semantic reconciliation")?;
+    Ok(raw_message_ids
+        .into_iter()
+        .filter_map(|message_id| u64::try_from(message_id).ok())
+        .collect())
+}
+
+fn semantic_index_contains_only_current_messages(
+    index_path: &Path,
+    current_message_ids: &HashSet<u64>,
+) -> Result<bool> {
+    let index = FsVectorIndex::open(index_path).map_err(|err| {
+        anyhow::anyhow!(
+            "open semantic artifact for current-message validation {}: {err}",
+            index_path.display()
+        )
+    })?;
+    if index.wal_record_count() > 0 {
+        return Ok(false);
+    }
+    for record_index in 0..index.record_count() {
+        if index.is_deleted(record_index) {
+            return Ok(false);
+        }
+        let doc_id = index.doc_id_at(record_index).map_err(|err| {
+            anyhow::anyhow!("read semantic document id during current-message validation: {err}")
+        })?;
+        let semantic_id = crate::search::vector_index::parse_semantic_doc_id(doc_id)
+            .ok_or_else(|| anyhow::anyhow!("invalid cass semantic document id: {doc_id}"))?;
+        if !current_message_ids.contains(&semantic_id.message_id) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn filter_semantic_watch_once_inputs(inputs: &mut Vec<EmbeddingInput>) {
     inputs.retain(|message| {
         !is_hard_message_noise(semantic_role_name(message.role), &message.content)
@@ -15502,17 +15550,37 @@ fn select_targeted_semantic_watch_once_inputs(
         && artifact.db_fingerprint.eq(&current_db_fingerprint)
     {
         let index_path = validate_semantic_watch_once_artifact(data_dir, artifact, indexer, tier)?;
-        return Ok(TargetedSemanticWatchOnceSelection {
-            mode: TargetedSemanticWatchOnceMode::AlreadyCovered,
-            inputs: Vec::new(),
-            raw_max_message_id: (current_fingerprint.max_message_id > 0)
-                .then_some(current_fingerprint.max_message_id),
-            tier,
-            index_path,
-            total_conversations: u64::try_from(total_conversations).unwrap_or(u64::MAX),
-            current_db_fingerprint,
-            manifest_before_db_fingerprint,
-            reason: "semantic_artifact_already_covers_db",
+        let current_message_ids = current_semantic_message_ids(storage)?;
+        let artifact_is_current =
+            semantic_index_contains_only_current_messages(&index_path, &current_message_ids)?;
+        return Ok(if artifact_is_current {
+            TargetedSemanticWatchOnceSelection {
+                mode: TargetedSemanticWatchOnceMode::AlreadyCovered,
+                inputs: Vec::new(),
+                raw_max_message_id: (current_fingerprint.max_message_id > 0)
+                    .then_some(current_fingerprint.max_message_id),
+                tier,
+                index_path,
+                total_conversations: u64::try_from(total_conversations).unwrap_or(u64::MAX),
+                current_db_fingerprint,
+                manifest_before_db_fingerprint,
+                current_message_ids: None,
+                reason: "semantic_artifact_already_covers_db",
+            }
+        } else {
+            TargetedSemanticWatchOnceSelection {
+                mode: TargetedSemanticWatchOnceMode::ReconcileExisting,
+                inputs: Vec::new(),
+                raw_max_message_id: (current_fingerprint.max_message_id > 0)
+                    .then_some(current_fingerprint.max_message_id),
+                tier,
+                index_path,
+                total_conversations: u64::try_from(total_conversations).unwrap_or(u64::MAX),
+                current_db_fingerprint,
+                manifest_before_db_fingerprint,
+                current_message_ids: Some(current_message_ids),
+                reason: "semantic_artifact_reconciled_with_current_db",
+            }
         });
     }
 
@@ -15536,6 +15604,7 @@ fn select_targeted_semantic_watch_once_inputs(
             total_conversations: u64::try_from(total_conversations).unwrap_or(u64::MAX),
             current_db_fingerprint,
             manifest_before_db_fingerprint,
+            current_message_ids: None,
             reason: "fresh_watch_once_db",
         });
     }
@@ -15566,21 +15635,34 @@ fn select_targeted_semantic_watch_once_inputs(
         );
     }
     let index_path = validate_semantic_watch_once_artifact(data_dir, &artifact, indexer, tier)?;
-    if !semantic_artifact_is_append_only_prefix(storage, artifact_fingerprint, current_fingerprint)?
-    {
-        anyhow::bail!(
-            "semantic watch-once cannot prove bounded coverage: existing semantic artifact is not an append-only prefix of the current DB"
-        );
-    }
-
+    let current_message_ids = current_semantic_message_ids(storage)?;
+    let append_only_prefix =
+        semantic_artifact_is_append_only_prefix(
+            storage,
+            artifact_fingerprint,
+            current_fingerprint,
+        )? && semantic_index_contains_only_current_messages(&index_path, &current_message_ids)?;
     let mut batch =
         packet_embedding_inputs_from_storage_since(storage, artifact_fingerprint.max_message_id)?;
     let raw_max_message_id = batch.raw_max_message_id.or_else(|| {
         (current_fingerprint.max_message_id > 0).then_some(current_fingerprint.max_message_id)
     });
     filter_semantic_watch_once_inputs(&mut batch.inputs);
+    let (mode, current_message_ids, reason) = if append_only_prefix {
+        (
+            TargetedSemanticWatchOnceMode::AppendToExisting,
+            None,
+            "semantic_artifact_is_append_only_prefix",
+        )
+    } else {
+        (
+            TargetedSemanticWatchOnceMode::ReconcileExisting,
+            Some(current_message_ids),
+            "semantic_artifact_reconciled_with_current_db",
+        )
+    };
     Ok(TargetedSemanticWatchOnceSelection {
-        mode: TargetedSemanticWatchOnceMode::AppendToExisting,
+        mode,
         inputs: batch.inputs,
         raw_max_message_id,
         tier,
@@ -15588,7 +15670,8 @@ fn select_targeted_semantic_watch_once_inputs(
         total_conversations: u64::try_from(total_conversations).unwrap_or(u64::MAX),
         current_db_fingerprint,
         manifest_before_db_fingerprint,
-        reason: "semantic_artifact_is_append_only_prefix",
+        current_message_ids,
+        reason,
     })
 }
 
@@ -15704,6 +15787,21 @@ fn run_targeted_semantic_watch_once_publish(
                     selection.index_path.display()
                 )
             })?;
+            u64::try_from(index.record_count()).unwrap_or(u64::MAX)
+        }
+        TargetedSemanticWatchOnceMode::ReconcileExisting => {
+            let current_message_ids = selection.current_message_ids.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "semantic reconciliation selection omitted current canonical message ids"
+                )
+            })?;
+            let index = indexer.reconcile_index_with_current_messages(
+                embedded,
+                data_dir,
+                selection.tier,
+                &selection.current_db_fingerprint,
+                current_message_ids,
+            )?;
             u64::try_from(index.record_count()).unwrap_or(u64::MAX)
         }
     };
@@ -45400,6 +45498,122 @@ mod tests {
             matches!(index.record_count(), 4),
             "wrong vector record count"
         );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn run_index_semantic_watch_once_repairs_deleted_prefix_conversation() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let data_dir = tmp.path().join("cass-data");
+        std::fs::create_dir_all(&data_dir)?;
+        let first = tmp
+            .path()
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("28")
+            .join("rollout-semantic-watch-once-repair-first.jsonl");
+        let second = first.with_file_name("rollout-semantic-watch-once-repair-second.jsonl");
+        let third = first.with_file_name("rollout-semantic-watch-once-repair-third.jsonl");
+        write_semantic_watch_once_codex_session(
+            &first,
+            "semantic-watch-once-repair-first",
+            "swonce-repair-one",
+        )?;
+        write_semantic_watch_once_codex_session(
+            &second,
+            "semantic-watch-once-repair-second",
+            "swonce-repair-two",
+        )?;
+        write_semantic_watch_once_codex_session(
+            &third,
+            "semantic-watch-once-repair-third",
+            "swonce-repair-three",
+        )?;
+
+        run_index(
+            semantic_watch_once_opts(&data_dir, &first, Arc::new(IndexingProgress::default())),
+            None,
+        )?;
+        run_index(
+            semantic_watch_once_opts(&data_dir, &second, Arc::new(IndexingProgress::default())),
+            None,
+        )?;
+
+        let storage = FrankenStorage::open(&data_dir.join("db.sqlite"))?;
+        let removed_conversation_id: i64 = storage.raw().query_row_map(
+            "SELECT id FROM conversations ORDER BY id ASC LIMIT 1",
+            &[],
+            |row| row.get_typed(0),
+        )?;
+        for statement in [
+            "DELETE FROM conversation_external_lookup WHERE conversation_id = ?1",
+            "DELETE FROM conversation_external_tail_lookup WHERE conversation_id = ?1",
+            "DELETE FROM messages WHERE conversation_id = ?1",
+            "DELETE FROM conversation_tail_state WHERE conversation_id = ?1",
+            "DELETE FROM conversations WHERE id = ?1",
+        ] {
+            storage
+                .raw()
+                .execute_compat(statement, &[ParamValue::from(removed_conversation_id)])?;
+        }
+        drop(storage);
+
+        let progress = Arc::new(IndexingProgress::default());
+        run_index(
+            semantic_watch_once_opts(&data_dir, &third, Arc::clone(&progress)),
+            None,
+        )?;
+
+        let stats = semantic_watch_once_stats(&progress)?;
+        anyhow::ensure!(stats.published, "semantic watch-once did not publish");
+        anyhow::ensure!(
+            matches!(
+                stats.reason.as_str(),
+                "semantic_artifact_reconciled_with_current_db"
+            ),
+            "wrong reason: {}",
+            stats.reason
+        );
+        anyhow::ensure!(matches!(stats.selected_docs, 2), "wrong selected doc count");
+        anyhow::ensure!(matches!(stats.embedded_docs, 2), "wrong embedded doc count");
+
+        let manifest = SemanticManifest::load_or_default(&data_dir)?;
+        let artifact = manifest.fast_tier.as_ref().context("fast artifact")?;
+        anyhow::ensure!(matches!(artifact.conversation_count, 2));
+        anyhow::ensure!(matches!(artifact.doc_count, 4));
+        anyhow::ensure!(matches!(
+            artifact.db_fingerprint.as_str(),
+            "content-v1:2:3:6"
+        ));
+
+        let storage = FrankenStorage::open(&data_dir.join("db.sqlite"))?;
+        let current_message_ids: HashSet<u64> = storage
+            .raw()
+            .query_map_collect(
+                "SELECT m.id
+                 FROM messages AS m
+                 INNER JOIN conversations AS c ON c.id = m.conversation_id",
+                &[],
+                |row| row.get_typed::<i64>(0),
+            )?
+            .into_iter()
+            .filter_map(message_id_from_db)
+            .collect();
+        let index = FsVectorIndex::open(&vector_index_path(&data_dir, "fnv1a-384"))?;
+        anyhow::ensure!(matches!(index.record_count(), 4));
+        for record_index in 0..index.record_count() {
+            let doc_id = index.doc_id_at(record_index)?;
+            let parsed = crate::search::vector_index::parse_semantic_doc_id(doc_id)
+                .with_context(|| format!("parse semantic doc id {doc_id}"))?;
+            anyhow::ensure!(
+                current_message_ids.contains(&parsed.message_id),
+                "stale semantic message {} survived reconciliation",
+                parsed.message_id
+            );
+        }
         Ok(())
     }
 

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -37,7 +37,8 @@ use crate::search::tantivy::{
     normalized_index_origin_host, normalized_index_origin_kind, normalized_index_source_id,
 };
 use crate::search::vector_index::{
-    ROLE_USER, SemanticDocId, VECTOR_INDEX_DIR, role_code_from_str, vector_index_path,
+    ROLE_USER, SemanticDocId, VECTOR_INDEX_DIR, parse_semantic_doc_id, role_code_from_str,
+    vector_index_path,
 };
 use crate::storage::sqlite::FrankenStorage;
 
@@ -2068,6 +2069,131 @@ impl SemanticIndexer {
         Ok(count)
     }
 
+    /// Rebuild the canonical FSVI artifact by reusing every still-current
+    /// vector and replacing only the supplied messages.
+    ///
+    /// The replacement is written to a staging artifact and atomically
+    /// published only after every retained and newly embedded record has been
+    /// validated. The live semantic artifact therefore remains usable if the
+    /// selective rewrite fails before publication.
+    pub fn reconcile_index_with_current_messages(
+        &self,
+        embedded_messages: Vec<EmbeddedMessage>,
+        data_dir: &Path,
+        tier: TierKind,
+        db_fingerprint: &str,
+        current_message_ids: &HashSet<u64>,
+    ) -> Result<FsVectorIndex> {
+        let index_path = vector_index_path(data_dir, self.embedder_id());
+        let staging_path =
+            semantic_staging_index_path(data_dir, tier, self.embedder_id(), db_fingerprint);
+        let mut current_index = FsVectorIndex::open(&index_path).map_err(|err| {
+            anyhow::anyhow!(
+                "open semantic index for selective reconciliation {}: {err}",
+                index_path.display()
+            )
+        })?;
+        if current_index.wal_record_count() > 0 {
+            current_index.compact().map_err(|err| {
+                anyhow::anyhow!("compact semantic index before selective reconciliation: {err}")
+            })?;
+        }
+
+        if let Some(parent) = staging_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let replacement_message_ids: HashSet<u64> = embedded_messages
+            .iter()
+            .map(|message| message.message_id)
+            .collect();
+        let mut writer = FsVectorIndex::create_with_revision(
+            &staging_path,
+            self.embedder_id(),
+            "1.0",
+            self.embedder_dimension(),
+            FsQuantization::F16,
+        )
+        .map_err(|err| anyhow::anyhow!("create reconciled fsvi staging index: {err}"))?;
+
+        let mut retained_docs = 0usize;
+        let mut removed_docs = 0usize;
+        for record_index in 0..current_index.record_count() {
+            if current_index.is_deleted(record_index) {
+                removed_docs = removed_docs.saturating_add(1);
+                continue;
+            }
+            let doc_id = current_index.doc_id_at(record_index).map_err(|err| {
+                anyhow::anyhow!("read semantic doc id during reconciliation: {err}")
+            })?;
+            let semantic_id = parse_semantic_doc_id(doc_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "semantic reconciliation found an invalid cass document id: {doc_id}"
+                )
+            })?;
+            if !current_message_ids.contains(&semantic_id.message_id)
+                || replacement_message_ids.contains(&semantic_id.message_id)
+            {
+                removed_docs = removed_docs.saturating_add(1);
+                continue;
+            }
+            let vector = current_index.vector_at_f32(record_index).map_err(|err| {
+                anyhow::anyhow!("read semantic vector during reconciliation: {err}")
+            })?;
+            writer
+                .write_record(doc_id, &vector)
+                .map_err(|err| anyhow::anyhow!("write retained semantic vector: {err}"))?;
+            retained_docs = retained_docs.saturating_add(1);
+        }
+
+        let embedded_docs = embedded_messages.len();
+        for embedded in embedded_messages {
+            if embedded.embedding.len() != self.embedder_dimension() {
+                bail!(
+                    "embedding dimension mismatch: expected {}, got {}",
+                    self.embedder_dimension(),
+                    embedded.embedding.len()
+                );
+            }
+            let doc_id = semantic_doc_id_for_embedded(&embedded);
+            writer
+                .write_record(&doc_id, &embedded.embedding)
+                .map_err(|err| anyhow::anyhow!("write replacement semantic vector: {err}"))?;
+        }
+        writer
+            .finish()
+            .map_err(|err| anyhow::anyhow!("finish reconciled fsvi staging index: {err}"))?;
+        let expected_docs = retained_docs.saturating_add(embedded_docs);
+        let staged = FsVectorIndex::open(&staging_path)
+            .map_err(|err| anyhow::anyhow!("open reconciled semantic staging index: {err}"))?;
+        if !staged.record_count().eq(&expected_docs) {
+            bail!(
+                "reconciled semantic staging count mismatch: expected {expected_docs}, observed {}",
+                staged.record_count()
+            );
+        }
+        drop(staged);
+        drop(current_index);
+
+        fs::rename(&staging_path, &index_path).with_context(|| {
+            format!(
+                "publish reconciled semantic index {} to {}",
+                staging_path.display(),
+                index_path.display()
+            )
+        })?;
+        sync_parent_directory(&index_path)?;
+        let published = FsVectorIndex::open(&index_path)
+            .map_err(|err| anyhow::anyhow!("open reconciled semantic index: {err}"))?;
+        tracing::info!(
+            retained_docs,
+            removed_docs,
+            embedded_docs,
+            published_docs = published.record_count(),
+            "published selectively reconciled semantic index"
+        );
+        Ok(published)
+    }
+
     fn write_backfill_staging_index(
         &self,
         embedded_messages: Vec<EmbeddedMessage>,
@@ -2966,6 +3092,46 @@ mod tests {
         assert_eq!(index.embedder_id(), indexer.embedder_id());
         assert_eq!(index.dimension(), indexer.embedder_dimension());
         assert_eq!(index.record_count(), 2);
+    }
+
+    #[test]
+    fn semantic_reconciliation_failure_preserves_live_artifact() -> Result<()> {
+        let indexer = SemanticIndexer::new("hash", None)?;
+        let initial = indexer.embed_messages(&[
+            EmbeddingInput::new(1, "retained semantic one"),
+            EmbeddingInput::new(2, "retained semantic two"),
+        ])?;
+        let tmp = tempdir()?;
+        indexer.build_and_save_index(initial, tmp.path())?;
+
+        let mut invalid_replacement =
+            indexer.embed_messages(&[EmbeddingInput::new(3, "invalid replacement")])?;
+        invalid_replacement[0].embedding.pop();
+        let err = match indexer.reconcile_index_with_current_messages(
+            invalid_replacement,
+            tmp.path(),
+            TierKind::Fast,
+            "content-v1:3:3:3",
+            &HashSet::from([1, 2, 3]),
+        ) {
+            Ok(_) => bail!("invalid semantic replacement unexpectedly succeeded"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("embedding dimension mismatch"));
+
+        let live = FsVectorIndex::open(&vector_index_path(tmp.path(), indexer.embedder_id()))?;
+        assert_eq!(live.record_count(), 2);
+        let mut live_message_ids = HashSet::new();
+        for record_index in 0..live.record_count() {
+            let doc_id = live
+                .doc_id_at(record_index)
+                .with_context(|| format!("missing semantic doc id at record {record_index}"))?;
+            let parsed = parse_semantic_doc_id(doc_id)
+                .with_context(|| format!("invalid semantic doc id {doc_id}"))?;
+            live_message_ids.insert(parsed.message_id);
+        }
+        assert_eq!(live_message_ids, HashSet::from([1, 2]));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reconcile mutable semantic watch-once prefixes without re-embedding the full corpus
- retain still-current vectors, drop stale/tombstoned records, and embed only the new tail
- stage and validate the replacement FSVI before atomic publication

## Context

The targeted semantic path added in #264 correctly handles an append-only canonical database, but it fails closed when a previously indexed conversation disappears from the canonical prefix while newer messages have arrived. SQLite remains the source of truth, so the semantic artifact must be able to converge without forcing a whole-corpus embedding rebuild.

The observed production shape was an artifact fingerprint whose historical prefix contained one more conversation than the current canonical prefix. The existing `semantic_artifact_is_append_only_prefix` guard therefore refused the incremental run.

## Changes

- add a reconciliation mode to targeted semantic watch-once selection
- validate existing FSVI message IDs against current canonical SQLite rows, including the already-covered path
- preserve the append-only and already-covered fast paths when their invariants hold
- reuse unchanged vectors during reconciliation and replace only newly selected message IDs
- compact WAL state, omit tombstones/stale IDs, write a deterministic staging artifact, validate its record count, then atomically rename it over the live FSVI
- add regressions for deleted-prefix convergence and failure-atomic publication

## Risk

- reconciliation performs an O(N) ID/vector scan only when append-only/current-artifact invariants fail; embedding work remains proportional to the new tail
- publication uses the existing semantic staging-path and atomic-rename conventions
- manifest publication still happens only after the FSVI has been published successfully
- the normal append-only watch-once path is unchanged

## Verification

- `cargo test run_index_semantic_watch_once_repairs_deleted_prefix_conversation --lib`
- `cargo test semantic_reconciliation_failure_preserves_live_artifact --lib`
- all five semantic watch-once tests pass
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- UBS changed-file scan: no new critical findings (upstream baseline 184; patch 184); compiler, Clippy, formatting, and test-build subchecks clean