### PR TITLE
fix(sources-doctor): update probe call sites for budget-envelope API (master does not compile)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97185,22 +97185,32 @@ fn run_sources_doctor(
     let mut all_diagnostics = Vec::new();
     let mut observations = Vec::new();
 
+    let fleet_budget_cfg = configured_fleet_probe_budget();
+    let total_budget =
+        crate::robot_budget_envelope::RobotBudget::new(fleet_budget_cfg.total_ms);
+
     for source in sources_to_check {
         let source_start = std::time::Instant::now();
+        let host_budget = crate::robot_budget_envelope::RobotBudget::with_start(
+            fleet_budget_cfg.per_host_ms,
+            source_start,
+        );
         let mut checks = Vec::new();
 
         // Check 1: SSH connectivity
         let host = source.host.as_deref().unwrap_or("unknown");
         let fixture_probe = load_source_doctor_fixture_probe(host)?;
-        let ssh_check = fixture_probe
-            .as_ref()
-            .map_or_else(|| check_ssh_connectivity(host), |probe| probe.ssh_check());
+        let ssh_check = fixture_probe.as_ref().map_or_else(
+            || check_ssh_connectivity(host, remaining_probe_timeout(&host_budget, &total_budget)),
+            |probe| probe.ssh_check(),
+        );
         checks.push(ssh_check);
 
         // Check 2: rsync availability on remote
-        let rsync_check = fixture_probe
-            .as_ref()
-            .map_or_else(|| check_rsync_available(host), |probe| probe.rsync_check());
+        let rsync_check = fixture_probe.as_ref().map_or_else(
+            || check_rsync_available(host, remaining_probe_timeout(&host_budget, &total_budget)),
+            |probe| probe.rsync_check(),
+        );
         checks.push(rsync_check);
 
         // Check 3: Remote paths exist
@@ -97214,7 +97224,13 @@ fn run_sources_doctor(
                 });
             } else {
                 checks.push(fixture_probe.as_ref().map_or_else(
-                    || check_remote_path(host, path),
+                    || {
+                        check_remote_path(
+                            host,
+                            path,
+                            remaining_probe_timeout(&host_budget, &total_budget),
+                        )
+                    },
                     |probe| probe.remote_path_check(path),
                 ));
             }
@@ -97266,7 +97282,12 @@ fn run_sources_doctor(
         if observation.host_reachable {
             if source.host.is_some() {
                 let probe = fixture_probe.as_ref().map_or_else(
-                    || check_remote_cass(host),
+                    || {
+                        check_remote_cass(
+                            host,
+                            remaining_probe_timeout(&host_budget, &total_budget),
+                        )
+                    },
                     SourceDoctorFixtureProbe::remote_cass_probe,
                 );
                 if let Some(uname) = probe.os.as_deref() {
@@ -97354,9 +97375,15 @@ fn run_sources_doctor(
     });
 
     if let Some(_fmt) = structured_format {
+        let budget_block = crate::robot_budget_envelope::BudgetBlock::from_budget(
+            &total_budget,
+            Vec::new(),
+            None,
+        );
         let output = SourcesDoctorOutput {
             health: &health_report,
             diagnostics: &all_diagnostics,
+            budget: &budget_block,
         };
         println!(
             "{}",
@@ -99138,7 +99165,17 @@ fn probe_remote_host_for_rehearsal(
 ) {
     use crate::fleet_doctor_schema::{HostDoctorReport, HostProbeStatus, Platform};
     let start = std::time::Instant::now();
-    let probe = check_remote_cass(host);
+    let rehearsal_budget_cfg = configured_fleet_probe_budget();
+    let rehearsal_total_budget =
+        crate::robot_budget_envelope::RobotBudget::new(rehearsal_budget_cfg.total_ms);
+    let rehearsal_host_budget = crate::robot_budget_envelope::RobotBudget::with_start(
+        rehearsal_budget_cfg.per_host_ms,
+        start,
+    );
+    let probe = check_remote_cass(
+        host,
+        remaining_probe_timeout(&rehearsal_host_budget, &rehearsal_total_budget),
+    );
     let elapsed = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
     let platform = probe
         .os


### PR DESCRIPTION
## Summary

HEAD (e1ad357, "feat(robot): additive budget envelope metadata for robot payloads") does not compile: the commit added `timeout` parameters to `check_ssh_connectivity`, `check_rsync_available`, `check_remote_path`, and `check_remote_cass`, plus a `budget` field to `SourcesDoctorOutput`, but left six call sites un-updated.

```
src/lib.rs:97197: error[E0061]: this function takes 2 arguments but 1 argument was supplied
src/lib.rs:97203: error[E0061]: ...
src/lib.rs:97217: error[E0061]: this function takes 3 arguments but 2 arguments were supplied
src/lib.rs:97269: error[E0061]: ...
src/lib.rs:97357: error[E0063]: missing field `budget` in initializer of `SourcesDoctorOutput`
src/lib.rs:99141: error[E0061]: ...
```

## Fix

Wire the existing budget helpers through the call sites, matching the design intent of the budget-envelope change:

- `run_sources_doctor` builds a total budget (60s) + per-host budget (8s) from `configured_fleet_probe_budget()`, and passes `remaining_probe_timeout(&host_budget, &total_budget)` into each probe call
- the structured doctor payload now carries a `BudgetBlock::from_budget(&total_budget, ...)` snapshot
- `probe_remote_host_for_rehearsal` builds its own budgets the same way

`cargo check` passes; behavior under env overrides (`CASS_FLEET_PER_HOST_BUDGET_MS` / `CASS_FLEET_BUDGET_MS`) is unchanged.

Single cherry-picked commit; no other changes.