### PR TITLE
build(deps): patch fsqlite/fsqlite-types to git rev matching Cargo.lock (fresh clone cannot build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,3 +316,10 @@ path = "tests/upgrade/mod.rs"
 [[test]]
 name = "recovery"
 path = "tests/recovery/mod.rs"
+
+# fsqlite/fsqlite-types 0.1.19 are not available on crates.io (yanked or never
+# published); Cargo.lock already pins them to this git rev. Patch crates.io
+# resolution to match the lockfile so fresh builds succeed.
+[patch.crates-io]
+fsqlite = { git = "https://github.com/Dicklesworthstone/frankensqlite", rev = "f9cc3294" }
+fsqlite-types = { git = "https://github.com/Dicklesworthstone/frankensqlite", rev = "f9cc3294" }


### PR DESCRIPTION
## Summary

A fresh clone of this repo fails dependency resolution:

```
error: failed to select a version for the requirement `fsqlite = "=0.1.19"`
candidate versions found which didn't match: 0.1.18, 0.1.17, 0.1.16, ...
location searched: crates.io index
```

`fsqlite`/`fsqlite-types` 0.1.19 are not resolvable from crates.io (yanked or never published), while `Cargo.lock` already records both crates from `git+https://github.com/Dicklesworthstone/frankensqlite?rev=f9cc3294`. The manifest and the lockfile disagree, so `cargo check`/`cargo build` fail before compiling anything.

## Fix

Add a `[patch.crates-io]` section pointing both crates at the exact git rev the lockfile pins (`f9cc3294`). With this, a fresh clone builds cleanly and the lockfile stays valid unchanged.

If you'd rather republish 0.1.19 to crates.io, that works too — but this patch restores reproducible builds today and matches how the other franken-* dependencies are already sourced (git pins).