### PR TITLE
fix(sources): unquoted rsync remote spec for openrsync remotes

### DIFF
--- a/src/sources/sync.rs
+++ b/src/sources/sync.rs
@@ -54,8 +54,9 @@ use std::net::{Shutdown, TcpStream};
 /// neither.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RsyncArgProtection {
-    /// Neither flag supported — callers must manually quote remote paths for
-    /// the remote login shell.
+    /// Neither flag supported — rsync is invoked without an arg-protection
+    /// flag, and local rsync backslash-escapes the remote path itself when
+    /// building the remote command line (see `remote_spec_for_rsync`).
     None,
     /// rsync 3.0.0..3.4.0 — original flag name.
     ProtectArgs,
@@ -120,14 +121,18 @@ fn remote_spec_for_shell_bound_copy(host: &str, remote_path: &str) -> String {
     format!("{host}:{}", quote_remote_shell_path(remote_path))
 }
 
-fn remote_spec_for_rsync(host: &str, remote_path: &str, protect_args_supported: bool) -> String {
-    if protect_args_supported {
-        // With --protect-args, rsync handles its own escaping over the wire
-        format!("{host}:{remote_path}")
-    } else {
-        // Without it (e.g. openrsync), we must manually quote for the remote shell
-        remote_spec_for_shell_bound_copy(host, remote_path)
-    }
+fn remote_spec_for_rsync(host: &str, remote_path: &str) -> String {
+    // Pass the path through unquoted: local rsync builds the remote command
+    // line itself and backslash-escapes spaces and shell-special characters
+    // in the path when arg protection is unavailable, so this works with and
+    // without --protect-args/--secluded-args. Manually shell-quoting here is
+    // actively wrong for rsync: the literal quotes survive into the remote
+    // path and the remote reports "(l)stat: No such file or directory"
+    // (observed with openrsync on macOS 15+). Note that without arg
+    // protection the remote shell may still expand wildcard characters in
+    // the path; that is inherent to rsync's no-protection mode and cannot be
+    // fixed by quoting (which breaks the path entirely).
+    format!("{host}:{remote_path}")
 }
 
 fn run_rsync_command(
@@ -1194,8 +1199,7 @@ impl SyncEngine {
         } else {
             detect_rsync_arg_protection()
         };
-        let protect_args_supported = arg_protection.is_supported();
-        let remote_spec = remote_spec_for_rsync(host, &expanded_path, protect_args_supported);
+        let remote_spec = remote_spec_for_rsync(host, &expanded_path);
         let ssh_opts = strict_ssh_command_for_rsync(self.connection_timeout);
 
         let local_path_str = match local_path.to_str() {
@@ -1253,10 +1257,10 @@ impl SyncEngine {
                 host = %host,
                 remote_path = %expanded_path,
                 protection_flag = ?arg_protection.flag(),
-                "remote rsync rejected argument-protection flag; retrying with shell-quoted remote path"
+                "remote rsync rejected argument-protection flag; retrying without it"
             );
 
-            let fallback_remote_spec = remote_spec_for_rsync(host, &expanded_path, false);
+            let fallback_remote_spec = remote_spec_for_rsync(host, &expanded_path);
             let retry = match run_rsync_command(
                 &timeout_str,
                 &ssh_opts,
@@ -1404,7 +1408,7 @@ impl SyncEngine {
         // E.g. C:\Users\george\AppData\... → /mnt/c/Users/george/AppData/...
         let wsl_dest = windows_path_to_wsl(local_path_str);
 
-        let remote_spec = remote_spec_for_rsync(host, &expanded_path, true);
+        let remote_spec = remote_spec_for_rsync(host, &expanded_path);
         let ssh_opts = strict_ssh_command_for_rsync(self.connection_timeout);
         let timeout_str = self.transfer_timeout.to_string();
 
@@ -3698,19 +3702,32 @@ Total transferred file size: 1,234 bytes
     }
 
     #[test]
-    fn test_remote_spec_for_rsync_quotes_only_when_needed() {
+    fn test_remote_spec_for_rsync_never_shell_quotes_path() {
+        // The rsync remote spec must always be the plain host:path form, with
+        // no manual shell quoting: local rsync backslash-escapes the path
+        // itself when building the remote command line, so quoting leaves
+        // literal quotes in the remote path and breaks the transfer (observed
+        // with openrsync remotes on macOS 15+).
         assert_eq!(
-            remote_spec_for_rsync("work-mac", "/tmp/has space", true),
+            remote_spec_for_rsync("work-mac", "/tmp/has space"),
             "work-mac:/tmp/has space"
         );
         assert_eq!(
-            remote_spec_for_rsync("work-mac", "/tmp/that's all", true),
+            remote_spec_for_rsync("work-mac", "/tmp/that's all"),
             "work-mac:/tmp/that's all"
         );
         assert_eq!(
-            remote_spec_for_rsync("work-mac", "/tmp/has space", false),
-            "work-mac:'/tmp/has space'"
+            remote_spec_for_rsync("work-mac", "/Users/x/.cursor"),
+            "work-mac:/Users/x/.cursor"
         );
+        // No shell-quoting is added around paths that don't themselves
+        // contain quote characters.
+        for path in ["/tmp/has space", "/Users/x/.cursor"] {
+            assert!(
+                !remote_spec_for_rsync("work-mac", path).contains('\''),
+                "rsync remote spec must not contain shell quotes"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`cass sources sync` against a macOS 15+ host (Apple openrsync) silently transfers nothing: every configured path warns `Remote path not found` even though it exists.

The openrsync detection half works (probe flags `openrsync: protocol version 29`, arg protection is set to `None`), but the spec generated in that branch is broken: `remote_spec_for_rsync` fell back to `remote_spec_for_shell_bound_copy`, producing a single-quoted spec `host:'/Users/x/.cursor'`. Local rsync backslash-escapes the quote characters when building the remote command line, so they survive into the remote path and openrsync fails with:

```
rsync(...): error: '/Users/x/.cursor/': (l)stat: No such file or directory
```

Repro (local rsync 3.2.7 → macOS openrsync remote):

- `rsync -avz --partial -e ssh "host:'/Users/x/.cursor/'" dest/` → fails as above
- `rsync -avz --partial -e ssh host:/Users/x/.cursor/ dest/` → works

## Fix

`remote_spec_for_rsync` now always emits the plain `host:path` form. When no arg-protection flag is used, local rsync performs its own escaping of spaces and shell-specials in the remote path (the decades-old default behavior), so the unquoted spec works both with and without `--protect-args`/`--secluded-args`. Manual shell quoting was only ever correct for the scp/sftp code paths, where a remote shell genuinely parses the command string — those are untouched.

Known limitation, noted in a code comment: without arg protection the remote shell may glob-expand literal wildcard characters in a path — inherent to rsync's no-protection mode and not fixable by quoting.

Completes the quoted-path fix from #191 (which covered Homebrew rsync 3.4.1 local mis-detection; this covers the remote-openrsync branch).

## Verification

- `cargo test --lib sources::sync` → 80 passed, 0 failed (rewritten spec test asserts no shell quoting in all modes; existing openrsync tests untouched)
- Real e2e, built binary → macOS openrsync host with 22 configured paths: **all synced, 7,756 files / 4.30 GB, zero warnings**, including space-containing `~/Library/Application Support/...` paths and previously-failing `~/.cursor`, `~/.claude`, `~/.codex/sessions`
- Regression: same binary → Ubuntu GNU rsync 3.2.7 remote syncs cleanly; `Remote path not found` now appears only for paths verified genuinely missing on the host