### PR TITLE
feat(connectors): wire up the Goose connector (24th provider)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,6 +472,7 @@ coding_agent_session_search/
 │   │   ├── vibe.rs               # Vibe sessions
 │   │   ├── crush.rs               # Crush sessions
 │   │   ├── hermes.rs              # Hermes sessions
+│   │   ├── goose.rs               # Goose sessions
 │   │   ├── kimi.rs                # Kimi Code sessions
 │   │   ├── qwen.rs                # Qwen Code sessions
 │   │   ├── openhands.rs           # OpenHands sessions
@@ -562,6 +563,7 @@ cass robot-docs guide         # LLM-optimized docs
 | Vibe | `vibe.rs` | JSONL |
 | Crush | `crush.rs` | JSONL |
 | Hermes | `hermes.rs` | JSONL |
+| Goose | `goose.rs` | SQLite / JSONL |
 | Kimi Code | `kimi.rs` | JSONL |
 | Qwen Code | `qwen.rs` | JSONL |
 | Factory (Droid) | `factory.rs` | JSONL |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ engine fix for the shipped
 FTS5 leaf-overflow (implemented + tested in frankensqlite, pending a dependency
 re-pin).
 
+### Added
+
+- **Goose connector (24th provider)**. cass now indexes
+  [Goose](https://github.com/block/goose) sessions instead of merely detecting
+  them. The parser already existed upstream in `franken_agent_detection`; cass
+  simply had not enabled the `goose` feature, so `goose` sat in the
+  detection-only set alongside `continue`/`windsurf` — probe paths and
+  `cass diag` entries, but no ingest. Enabling the feature registers
+  `GooseConnector` through the existing factory registry, which reads the
+  v1.20+ SQLite store (`~/.local/share/goose/sessions/sessions.db`) and falls
+  back to the pre-v1.20 per-session `*.jsonl` layout (including legacy
+  `~/.goose/sessions`). `GOOSE_PATH_ROOT` / `GOOSE_SQLITE_DB` override
+  discovery. Connector count assertions move 23 → 24.
+
 ### Fixed
 
 - **[#368](https://github.com/Dicklesworthstone/coding_agent_session_search/issues/368)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ bytemuck = "1.25.0"
 # binaries crashed pre-AVX2 CPUs at static init (#256/#307). No ONNX means no
 # AVX-static-init hazard and no separate `-baseline` artifact is needed.
 frankensearch = { version = "0.3.2", git = "https://github.com/Dicklesworthstone/frankensearch", rev = "ad8e29eaa03c9f29abc472d895a0ea9bcbe04ff1", default-features = false, features = ["hash", "cass-compat", "ann", "native"] }
-franken-agent-detection = { version = "0.1.10", git = "https://github.com/Dicklesworthstone/franken_agent_detection", rev = "dd2c694096d959ba87e0f6a44e87450b34144d3f", features = ["connectors", "cursor", "chatgpt", "opencode", "crush", "hermes"] }
+franken-agent-detection = { version = "0.1.10", git = "https://github.com/Dicklesworthstone/franken_agent_detection", rev = "dd2c694096d959ba87e0f6a44e87450b34144d3f", features = ["connectors", "cursor", "chatgpt", "opencode", "crush", "hermes", "goose"] }
 wide = "1.4.0"  # Portable SIMD for P0 Opt 2: SIMD dot product
 arrayvec = "0.7.6"  # Stack-based arrays for P1 Opt 1.4: Edge N-gram optimization
 bloomfilter = "3.0.1"  # Probabilistic membership testing for P2 Opt 3.3: Workspace Cache

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![License](https://img.shields.io/badge/license-MIT%2BOpenAI%2FAnthropic%20Rider-green.svg)
 
 **Unified, high-performance TUI to index and search your local coding agent history.**
-Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, GitHub Copilot Chat, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Hermes, Kimi Code, Qwen Code, Factory (Droid), Antigravity, OpenHands, and Grok Build into a single, searchable timeline.
+Aggregates sessions from Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, GitHub Copilot Chat, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Hermes, Goose, Kimi Code, Qwen Code, Factory (Droid), Antigravity, OpenHands, and Grok Build into a single, searchable timeline.
 
 <div align="center">
 
@@ -360,7 +360,7 @@ cass export-html session.jsonl --json
 ```
 
 ### 🔗 Universal Connectors
-Ingests history from 23 local agents, normalizing them into a unified `Conversation -> Message -> Snippet` model. `cass capabilities --json | jq .connectors` is the canonical machine-readable inventory (kept in lockstep with the runtime registry):
+Ingests history from 24 local agents, normalizing them into a unified `Conversation -> Message -> Snippet` model. `cass capabilities --json | jq .connectors` is the canonical machine-readable inventory (kept in lockstep with the runtime registry):
 - **Codex**: `~/.codex/sessions` (Rollout JSONL)
 - **Cline**: VS Code global storage (Task directories)
 - **Gemini CLI**: `~/.gemini/tmp` (Chat JSON)
@@ -380,6 +380,7 @@ Ingests history from 23 local agents, normalizing them into a unified `Conversat
 - **OpenClaw**: `~/.openclaw/agents/*/sessions` (Session JSONL)
 - **Crush**: `~/.crush/crush.db` and per-project `.crush/crush.db` (SQLite)
 - **Hermes**: `~/.hermes/state.db` and project-local `.hermes/state.db` (SQLite)
+- **Goose**: `~/.local/share/goose/sessions/sessions.db` (SQLite, Goose v1.20+), falling back to per-session `*.jsonl` under the same directory or legacy `~/.goose/sessions` (override the base dir with `GOOSE_PATH_ROOT`, or point at a database directly with `GOOSE_SQLITE_DB`)
 - **Kimi Code**: `$KIMI_CODE_HOME/sessions/*/*/agents/*/wire.jsonl` (default `~/.kimi-code`; sub-agents index as `<sessionId>:<agentId>`), plus the legacy `~/.kimi/sessions/*/*/wire.jsonl` layout (Session JSONL)
 - **Qwen Code**: `~/.qwen/tmp/*/chats/session-*.json` (Chat JSON)
 - **Factory (Droid)**: `~/.factory/sessions` (JSONL files organized by workspace slug)
@@ -2145,6 +2146,7 @@ classDiagram
  Connector <|-- OpenClawConnector
  Connector <|-- CrushConnector
  Connector <|-- HermesConnector
+ Connector <|-- GooseConnector
  Connector <|-- KimiConnector
  Connector <|-- QwenConnector
 
@@ -2166,6 +2168,7 @@ classDiagram
  OpenClawConnector ..> NormalizedConversation : emits
  CrushConnector ..> NormalizedConversation : emits
  HermesConnector ..> NormalizedConversation : emits
+ GooseConnector ..> NormalizedConversation : emits
  KimiConnector ..> NormalizedConversation : emits
  QwenConnector ..> NormalizedConversation : emits
 ```
@@ -2180,7 +2183,7 @@ classDiagram
 `cass` uses frankensqlite as the durable source of truth and frankensearch as a derived speed layer, powered by a suite of integrated "franken" libraries.
 
 ### The Pipeline
-1. **Discovery**: [franken_agent_detection](https://github.com/Dicklesworthstone/franken_agent_detection) auto-discovers sessions from 23 coding agents (Claude Code, Codex, Cursor, Gemini, Aider, Amp, Cline, OpenCode, ChatGPT, Pi Agent, Copilot, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Hermes, Kimi, Qwen, Factory, OpenHands, Antigravity, Grok Build).
+1. **Discovery**: [franken_agent_detection](https://github.com/Dicklesworthstone/franken_agent_detection) auto-discovers sessions from 24 coding agents (Claude Code, Codex, Cursor, Gemini, Aider, Amp, Cline, OpenCode, ChatGPT, Pi Agent, Copilot, Copilot CLI, OpenClaw, Clawdbot, Vibe, Crush, Hermes, Goose, Kimi, Qwen, Factory, OpenHands, Antigravity, Grok Build).
 2. **Storage (frankensqlite)**: The **Source of Truth**. Data is persisted to a normalized SQLite schema (`messages`, `conversations`, `agents`) via [frankensqlite](https://github.com/Dicklesworthstone/frankensqlite) — a pure-Rust SQLite reimplementation with `BEGIN CONCURRENT` support for MVCC multi-writer transactions.
 3. **Search Index (frankensearch)**: The **Speed Layer**. New messages are incrementally pushed to a unified search index via [frankensearch](https://github.com/Dicklesworthstone/frankensearch) which provides BM25 lexical search, semantic embeddings, RRF fusion, and cross-encoder reranking in a single library.
  * **Fields**: `title`, `content`, `agent`, `workspace`, `created_at`.
@@ -2216,6 +2219,7 @@ flowchart LR
  A18[Hermes]:::pastel
  A19[Kimi]:::pastel
  A20[Qwen]:::pastel
+ A21[Goose]:::pastel
  end
 
  subgraph Remote["Remote Sources"]

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: "Coding Agent Session Search - unified CLI/TUI to index and search 
 
 # CASS - Coding Agent Session Search
 
-Unified, high-performance CLI/TUI to index and search your local coding agent history. Aggregates sessions from **23 agents**, including Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, Factory (Droid), OpenHands, Antigravity, and Grok Build.
+Unified, high-performance CLI/TUI to index and search your local coding agent history. Aggregates sessions from **24 agents**, including Codex, Claude Code, Gemini CLI, Cline, OpenCode, Amp, Cursor, ChatGPT, Aider, Pi-Agent, Factory (Droid), OpenHands, Antigravity, and Grok Build.
 
 ## CRITICAL: Robot Mode Required for AI Agents
 
@@ -575,7 +575,7 @@ Final_Score = BM25_Score × Match_Quality + α × Recency_Factor
 
 ---
 
-## Supported Agents (23 Connectors)
+## Supported Agents (24 Connectors)
 
 | Agent | Location | Format |
 |-------|----------|--------|
@@ -597,6 +597,7 @@ Final_Score = BM25_Score × Match_Quality + α × Recency_Factor
 | **Vibe** | `~/.vibe/logs/session` | JSONL |
 | **Crush** | `~/.crush/crush.db` | SQLite |
 | **Hermes** | `~/.hermes` | JSONL |
+| **Goose** | `~/.local/share/goose/sessions` | SQLite / JSONL |
 | **Kimi Code** | `~/.kimi/sessions` | JSONL |
 | **Qwen Code** | `~/.qwen/tmp` | JSON / JSONL |
 | **OpenHands** | `~/.openhands/conversations` | JSON event stream |

--- a/build.rs
+++ b/build.rs
@@ -112,6 +112,7 @@ const CONTRACTS: &[DependencyContract] = &[
             "connectors",
             "crush",
             "cursor",
+            "goose",
             "hermes",
             "opencode",
         ],

--- a/src/connectors/goose.rs
+++ b/src/connectors/goose.rs
@@ -1,0 +1,5 @@
+//! Connector for Block's Goose agent sessions.
+//!
+//! Implementation lives in `franken_agent_detection::connectors::goose`.
+
+pub use franken_agent_detection::connectors::goose::GooseConnector;

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -212,6 +212,7 @@ pub mod crush;
 pub mod cursor;
 pub mod factory;
 pub mod gemini;
+pub mod goose;
 pub mod grok;
 pub mod hermes;
 pub mod kimi;

--- a/src/html_export/renderer.rs
+++ b/src/html_export/renderer.rs
@@ -512,6 +512,7 @@ pub fn agent_css_class(slug: &str) -> &'static str {
         "vibe" | "mistral" => "agent-chatgpt",
         "crush" => "agent-amp",
         "hermes" => "agent-hermes",
+        "goose" => "agent-goose",
         "openhands" | "open_hands" => "agent-aider",
         _ => "agent-default",
     }
@@ -544,6 +545,7 @@ pub fn agent_display_name(slug: &str) -> &'static str {
         "mistral" => "Mistral",
         "crush" => "Crush",
         "hermes" => "Hermes",
+        "goose" => "Goose",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openhands" | "open_hands" => "OpenHands",

--- a/src/html_export/styles.rs
+++ b/src/html_export/styles.rs
@@ -1579,6 +1579,7 @@ pre:hover .copy-code-btn { opacity: 1; }
 .agent-amp .message-assistant { border-left-color: oklch(0.7 0.18 270); }
 .agent-grok .message-assistant { border-left-color: oklch(0.7 0.22 350); }
 .agent-hermes .message-assistant { border-left-color: oklch(0.78 0.16 95); }
+.agent-goose .message-assistant { border-left-color: oklch(0.74 0.07 75); }
 
 /* Print styles */
 @media print {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -241,6 +241,7 @@ const INPUT_AUTOCOMPLETE_AGENT_HINTS: &[&str] = &[
     "cursor",
     "factory",
     "gemini",
+    "goose",
     "kimi",
     "opencode",
     "openclaw",
@@ -3084,6 +3085,7 @@ fn legacy_agent_color(agent: &str) -> ftui::PackedRgba {
         "copilot" => ftui::PackedRgba::rgb(92, 200, 120), // blue-green
         "copilot_cli" => ftui::PackedRgba::rgb(80, 170, 230), // navy
         "crush" => ftui::PackedRgba::rgb(255, 120, 80), // coral
+        "goose" => ftui::PackedRgba::rgb(198, 166, 122), // taupe
         "kimi" => ftui::PackedRgba::rgb(190, 220, 80), // yellow-green
         "qwen" => ftui::PackedRgba::rgb(80, 210, 180), // mint
         _ => ftui::PackedRgba::rgb(169, 169, 169),     // gray fallback

--- a/src/ui/components/theme.rs
+++ b/src/ui/components/theme.rs
@@ -157,6 +157,9 @@ pub mod colors {
     /// Hermes Agent - dim gold tint
     pub const AGENT_HERMES_BG: Color = Color::rgb(40, 34, 18); // #282212 - gold
 
+    /// Goose - warm taupe tint
+    pub const AGENT_GOOSE_BG: Color = Color::rgb(38, 34, 30); // #26221e - taupe
+
     // ═══════════════════════════════════════════════════════════════════════════
     // ROLE-AWARE BACKGROUND TINTS - Subtle backgrounds per message type
     // ═══════════════════════════════════════════════════════════════════════════
@@ -471,6 +474,7 @@ impl ThemePalette {
             "copilot_cli" => (colors::AGENT_COPILOT_CLI_BG, PackedRgba::rgb(80, 170, 230)), // Navy
             "crush" => (colors::AGENT_CRUSH_BG, PackedRgba::rgb(255, 120, 80)),        // Coral
             "hermes" => (colors::AGENT_HERMES_BG, PackedRgba::rgb(240, 200, 100)),     // Gold
+            "goose" => (colors::AGENT_GOOSE_BG, PackedRgba::rgb(198, 166, 122)),       // Taupe
             "kimi" => (colors::AGENT_KIMI_BG, PackedRgba::rgb(190, 220, 80)), // Yellow-green
             "qwen" => (colors::AGENT_QWEN_BG, PackedRgba::rgb(80, 210, 180)), // Mint
             _ => (colors::BG_DEEP, colors::ACCENT_PRIMARY),
@@ -508,6 +512,7 @@ impl ThemePalette {
             "copilot_cli" => "◑",
             "crush" => "✚",
             "hermes" => "▽",
+            "goose" => "◉",
             "kimi" => "✧",
             "qwen" => "◒",
             _ => "•",
@@ -1652,6 +1657,7 @@ mod tests {
         "copilot_cli",
         "crush",
         "hermes",
+        "goose",
         "kimi",
         "qwen",
     ];

--- a/tests/agent_detection_completeness.rs
+++ b/tests/agent_detection_completeness.rs
@@ -51,7 +51,10 @@ fn probe_slugs() -> HashSet<String> {
 
 /// Detection-only connectors: have probe paths and detection entries but
 /// no parser implementation (no entry in `get_connector_factories()`).
-const DETECTION_ONLY: &[&str] = &["goose", "continue", "windsurf"];
+///
+/// `goose` graduated out of this set once cass enabled the FAD `goose`
+/// feature — it now has a real parser and appears in the factory registry.
+const DETECTION_ONLY: &[&str] = &["continue", "windsurf"];
 
 /// Extract a function body from source code, including the braces.
 fn extract_function_body(source: &str, fn_prefix: &str) -> String {
@@ -134,19 +137,19 @@ fn connector_factories_all_instantiate_and_detect() {
     }
 }
 
-/// Feature-gated connectors (chatgpt, cursor, opencode, crush, hermes) are
-/// available because cass enables those features in Cargo.toml.
+/// Feature-gated connectors (chatgpt, cursor, opencode, crush, hermes, goose)
+/// are available because cass enables those features in Cargo.toml.
 #[test]
 fn feature_gated_connectors_available() {
     let slugs = factory_fad_slugs();
-    for gated in ["chatgpt", "cursor", "opencode", "crush", "hermes"] {
+    for gated in ["chatgpt", "cursor", "opencode", "crush", "hermes", "goose"] {
         assert!(
             slugs.contains(gated),
             "Feature-gated connector '{gated}' not found. \
              Check Cargo.toml enables the feature for franken-agent-detection"
         );
     }
-    assert_eq!(slugs.len(), 23, "Expected 23 connector factories");
+    assert_eq!(slugs.len(), 24, "Expected 24 connector factories");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/connector_goose.rs
+++ b/tests/connector_goose.rs
@@ -1,0 +1,274 @@
+//! Conformance harness for the Goose connector via CASS's FAD re-export.
+//!
+//! Goose v1.20+ stores sessions in a SQLite database at
+//! `~/.local/share/goose/sessions/sessions.db`. Schema:
+//!   `sessions`:  id (TEXT PK), description, working_dir,
+//!                created_at / updated_at (INTEGER epoch secs),
+//!                provider_name, model_config_json, session_type
+//!   `messages`:  message_id (TEXT PK), session_id, role,
+//!                content_json (JSON block array), created_timestamp
+//!                (INTEGER epoch secs), tokens, metadata_json
+//!
+//! Pre-v1.20 installs use `*.jsonl` files under the same sessions directory
+//! (or legacy `~/.goose/sessions/`); the connector reads both shapes.
+//!
+//! Goose was detection-only in cass until the FAD `goose` feature was enabled.
+//! This mirrors the resilience edge cases the other SQLite-backed connectors
+//! (crush, hermes) assert, so a malformed or partial Goose database degrades to
+//! an empty scan instead of failing the whole index run.
+
+use coding_agent_search::connectors::goose::GooseConnector;
+use coding_agent_search::connectors::{Connector, NormalizedConversation, ScanContext, ScanRoot};
+use frankensqlite::Connection;
+use frankensqlite::compat::ConnectionExt;
+use frankensqlite::params;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn create_goose_db(path: &Path) -> Connection {
+    let conn = Connection::open(path.to_string_lossy().as_ref()).expect("open goose db");
+    conn.execute(
+        "CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            description TEXT,
+            working_dir TEXT,
+            created_at INTEGER,
+            updated_at INTEGER,
+            provider_name TEXT,
+            model_config_json TEXT,
+            session_type TEXT
+        )",
+    )
+    .expect("create sessions");
+    conn.execute(
+        "CREATE TABLE messages (
+            session_id TEXT,
+            role TEXT,
+            content_json TEXT,
+            created_timestamp INTEGER,
+            tokens INTEGER,
+            metadata_json TEXT,
+            message_id TEXT PRIMARY KEY
+        )",
+    )
+    .expect("create messages");
+    conn
+}
+
+fn insert_session(
+    conn: &Connection,
+    id: &str,
+    description: Option<&str>,
+    working_dir: Option<&str>,
+    created_at: i64,
+    updated_at: i64,
+    provider_name: Option<&str>,
+    model_config_json: Option<&str>,
+) {
+    conn.execute_compat(
+        "INSERT INTO sessions
+            (id, description, working_dir, created_at, updated_at,
+             provider_name, model_config_json, session_type)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+        params![
+            id,
+            description,
+            working_dir,
+            created_at,
+            updated_at,
+            provider_name,
+            model_config_json
+        ],
+    )
+    .expect("insert goose session");
+}
+
+fn insert_message(
+    conn: &Connection,
+    message_id: &str,
+    session_id: &str,
+    role: &str,
+    text: &str,
+    created_timestamp: i64,
+) {
+    let content_json = json!([{ "type": "text", "text": text }]).to_string();
+    conn.execute_compat(
+        "INSERT INTO messages
+            (session_id, role, content_json, created_timestamp, tokens, metadata_json, message_id)
+         VALUES (?1, ?2, ?3, ?4, NULL, NULL, ?5)",
+        params![session_id, role, content_json, created_timestamp, message_id],
+    )
+    .expect("insert goose message");
+}
+
+/// Scan a single Goose database with an explicit scan root.
+///
+/// The explicit root matters for hermeticity: `ScanContext::local_default`
+/// leaves `scan_roots` empty, which puts the connector in default-detection
+/// mode and makes it additionally probe the *developer's real*
+/// `~/.local/share/goose/sessions/`. Passing the db file as an explicit
+/// `ScanRoot` keeps the scan confined to the fixture — `append_db_candidates`
+/// takes any `*.db` root verbatim, so fixtures need not be named
+/// `sessions.db`.
+fn scan_db(path: &Path) -> Vec<NormalizedConversation> {
+    let connector = GooseConnector::new();
+    let ctx = ScanContext::with_roots(
+        std::path::PathBuf::new(),
+        vec![ScanRoot::local(path.to_path_buf())],
+        None,
+    );
+    connector.scan(&ctx).expect("goose scan should not panic")
+}
+
+#[test]
+fn goose_happy_path_preserves_session_and_message_fields() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("sessions.db");
+    let conn = create_goose_db(&db_path);
+
+    insert_session(
+        &conn,
+        "sess-goose-1",
+        Some("Refactor the indexer"),
+        Some("/home/user/proj"),
+        1_700_000_000,
+        1_700_000_200,
+        Some("anthropic"),
+        Some(r#"{"model": "claude-sonnet-4"}"#),
+    );
+    insert_message(
+        &conn,
+        "msg-1",
+        "sess-goose-1",
+        "user",
+        "How do I split this module?",
+        1_700_000_010,
+    );
+    insert_message(
+        &conn,
+        "msg-2",
+        "sess-goose-1",
+        "assistant",
+        "Start by extracting the parser.",
+        1_700_000_020,
+    );
+    drop(conn);
+
+    let convs = scan_db(&db_path);
+    assert_eq!(convs.len(), 1, "one session must yield one conversation");
+
+    let conv = &convs[0];
+    assert_eq!(conv.agent_slug, "goose");
+    assert_eq!(conv.external_id.as_deref(), Some("sess-goose-1"));
+    assert_eq!(conv.title.as_deref(), Some("Refactor the indexer"));
+    assert_eq!(
+        conv.workspace.as_deref(),
+        Some(Path::new("/home/user/proj")),
+        "working_dir must survive as the conversation workspace"
+    );
+    assert_eq!(conv.metadata["session_id"], "sess-goose-1");
+    assert_eq!(conv.metadata["provider_name"], "anthropic");
+    assert_eq!(
+        conv.metadata["model_name"], "claude-sonnet-4",
+        "model must be parsed out of model_config_json"
+    );
+    assert_eq!(conv.metadata["source"], "sqlite");
+
+    assert_eq!(conv.messages.len(), 2);
+    assert_eq!(conv.messages[0].role, "user");
+    assert!(conv.messages[0].content.contains("split this module"));
+    assert_eq!(conv.messages[1].role, "assistant");
+    assert!(conv.messages[1].content.contains("extracting the parser"));
+}
+
+#[test]
+fn goose_messages_are_ordered_by_timestamp_not_insertion() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("sessions.db");
+    let conn = create_goose_db(&db_path);
+
+    insert_session(
+        &conn,
+        "sess-order",
+        None,
+        None,
+        1_700_000_000,
+        1_700_000_300,
+        None,
+        None,
+    );
+    // Inserted out of order on purpose: the connector orders by timestamp.
+    insert_message(&conn, "msg-late", "sess-order", "assistant", "second", 200);
+    insert_message(&conn, "msg-early", "sess-order", "user", "first", 100);
+    drop(conn);
+
+    let convs = scan_db(&db_path);
+    assert_eq!(convs.len(), 1);
+    let contents: Vec<&str> = convs[0]
+        .messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect();
+    assert_eq!(
+        contents,
+        vec!["first", "second"],
+        "messages must be ordered by created_timestamp"
+    );
+}
+
+#[test]
+fn goose_session_without_messages_is_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("sessions.db");
+    let conn = create_goose_db(&db_path);
+
+    insert_session(
+        &conn,
+        "sess-empty",
+        Some("No messages here"),
+        None,
+        1_700_000_000,
+        1_700_000_000,
+        None,
+        None,
+    );
+    drop(conn);
+
+    assert!(
+        scan_db(&db_path).is_empty(),
+        "a session with zero messages must not produce a conversation"
+    );
+}
+
+#[test]
+fn goose_empty_zero_byte_db_returns_empty_result() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("empty.db");
+    fs::write(&db_path, b"").unwrap();
+
+    assert!(scan_db(&db_path).is_empty());
+}
+
+#[test]
+fn goose_malformed_schema_returns_empty_result_without_panic() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("malformed.db");
+    let conn = Connection::open(db_path.to_string_lossy().as_ref()).expect("open db");
+    // `sessions` exists but `messages` is missing — scan must degrade to empty.
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        .expect("create incomplete sessions table");
+    drop(conn);
+
+    assert!(scan_db(&db_path).is_empty());
+}
+
+#[test]
+fn goose_non_utf8_bytes_return_empty_result_without_panic() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("non_utf8.db");
+    fs::write(&db_path, [0xff, 0xfe, 0xfd, 0x00, 0x80]).unwrap();
+
+    assert!(scan_db(&db_path).is_empty());
+}

--- a/tests/spec_connector_enumeration_completeness.rs
+++ b/tests/spec_connector_enumeration_completeness.rs
@@ -1,9 +1,9 @@
 //! INV-cass-19 — `cass diag --json::connectors` enumeration completeness.
 //!
-//! cass advertises support for **23 coding-agent providers**: aider, amp,
+//! cass advertises support for **24 coding-agent providers**: aider, amp,
 //! antigravity, chatgpt, claude_code, clawdbot, cline, codex, copilot,
-//! copilot_cli, crush, cursor, factory, gemini, grok, hermes, kimi, openclaw,
-//! opencode, openhands, pi_agent, qwen, vibe. Each is a separate
+//! copilot_cli, crush, cursor, factory, gemini, goose, grok, hermes, kimi,
+//! openclaw, opencode, openhands, pi_agent, qwen, vibe. Each is a separate
 //! `src/connectors/*.rs` re-export of a `franken_agent_detection::Connector`
 //! implementation, and `cass diag --json` exposes the per-connector detection
 //! state agents and operators use to triage source coverage.
@@ -28,7 +28,7 @@
 //! Two invariants:
 //!
 //!   1. The set of connector names emitted by `cass diag --json::
-//!      connectors[].name` exactly equals the documented set of 23.
+//!      connectors[].name` exactly equals the documented set of 24.
 //!      Equality is checked via `symmetric_difference` so the
 //!      diagnostic shows exactly what's missing or extra in either
 //!      direction.
@@ -59,7 +59,7 @@ fn ensure(condition: bool, message: impl Into<String>) -> TestResult {
     }
 }
 
-/// The canonical set of 23 documented provider connectors. Sourced from the
+/// The canonical set of 24 documented provider connectors. Sourced from the
 /// runtime registry `franken_agent_detection::get_connector_factories()` (as
 /// surfaced by `cass capabilities --json` / `cass diag --json`) under the
 /// franken-agent-detection features cass enables in Cargo.toml. A peer adding a
@@ -79,6 +79,7 @@ const DOCUMENTED_CONNECTOR_NAMES: &[&str] = &[
     "cursor",
     "factory",
     "gemini",
+    "goose",
     "grok",
     "hermes",
     "kimi",


### PR DESCRIPTION
## Summary

Goose was **detection-only** in cass — it had probe paths and a `cass diag` entry, but no ingest, so it sat in `DETECTION_ONLY` alongside `continue` and `windsurf`. The parser already existed upstream in `franken_agent_detection` (`src/connectors/goose.rs`, ~1700 lines with its own test suite); cass simply never enabled the `goose` feature.

Enabling the feature registers `GooseConnector` through the existing factory registry — `get_connector_factories()` already delegates to upstream, so **no new parsing code is added on the cass side**.

The connector reads the v1.20+ SQLite store at `~/.local/share/goose/sessions/sessions.db` and falls back to the pre-v1.20 per-session `*.jsonl` layout, including legacy `~/.goose/sessions`. `GOOSE_PATH_ROOT` / `GOOSE_SQLITE_DB` override discovery.

## Changes

| Area | Change |
|---|---|
| `Cargo.toml`, `build.rs` | Add `goose` to the FAD feature list and to the dependency contract's `expected_features` (validated as an exact set) |
| `src/connectors/goose.rs`, `mod.rs` | Re-export stub matching the `crush`/`hermes` pattern |
| `theme.rs`, `app.rs` | Taupe accent + `◉` glyph, autocomplete hint, legacy color |
| `renderer.rs`, `styles.rs` | Display name, CSS class, border color |
| Tests, docs | Connector count assertions and docs move 23 → 24 |

The theme/UI edits are **not cosmetic** — three existing tests gate them: agent accents, backgrounds, and icons are each asserted pairwise-distinct across `KNOWN_AGENTS`, and every `INPUT_AUTOCOMPLETE_AGENT_HINTS` slug must resolve to a non-fallback `legacy_agent_color`. (That last gate is why `hermes` is absent from the hints list today; `goose` is added to both sides to stay consistent.)

## Testing

New `tests/connector_goose.rs` covers the happy path (slug, `external_id`, title, workspace, model parsed from `model_config_json`, message roles/content), timestamp ordering, empty-session skip, and three resilience cases (zero-byte, malformed schema, non-UTF-8 bytes).

**24 tests pass:** `connector_goose` 6/6 · `agent_detection_completeness` 10/10 · `spec_connector_enumeration_completeness` 2/2 · theme/renderer/autocomplete gates 6/6.

Confirmed against the real binary:

```
$ cass diag --json | jq '.connectors | length'
24
$ cass diag --json | jq '.connectors[] | select(.name=="goose")'
{ "name": "goose", "path": "~/.local/share/goose/sessions", "found": true }
```

### One deliberate deviation from the existing harness

`tests/connector_goose.rs` uses `ScanContext::with_roots` rather than the `ScanContext::local_default` used by `tests/connector_hermes.rs`.

`local_default` leaves `scan_roots` empty, which puts the connector into default-detection mode — it then *additionally* scans the developer's real `~/.local/share/goose/sessions/` on top of the fixture. The fixture assertions (`assert_eq!(convs.len(), 1)` and the three empty-result cases) would fail on any machine that actually runs Goose, while passing in a clean CI container. This was reproduced on a machine with a live 320 KB `sessions.db`, not hypothetical.

Passing the db file as an explicit `ScanRoot` confines each scan to its fixture (`append_db_candidates` takes any `*.db` root verbatim, so fixtures need not be named `sessions.db`).

Worth a separate look: **`tests/connector_hermes.rs` uses the pattern this one avoids**, so it may be similarly exposed. I have not confirmed whether Hermes' `scan()` actually falls back to the home directory the way Goose's does — that needs checking before calling it a bug, and it's out of scope here.

## ⚠️ Pre-existing CI failure, unrelated to this PR

`cargo check --tests` is **already red on `main`**. `tests/connector_claude.rs` (34 errors) and `tests/parse_errors.rs` (18 errors) construct `ScanContext` as a three-field struct literal, but the pinned FAD rev (`dd2c694`) added a fourth field, `progress_tick`:

```rust
let ctx = ScanContext {
    data_dir: dir.path().join("fixture-claude"),
    scan_roots: Vec::new(),
    since_ts: None,     // <- missing `progress_tick`
};
```

Neither file is touched by this PR, and nothing here affects that struct — `progress_tick` is unconditional in FAD's `scan.rs`, not feature-gated. If CI runs `cargo test --all` or `cargo check --tests`, **it will fail for this pre-existing reason**, not because of the goose work. The fix is mechanical (add `progress_tick: None`, or switch to the `local_default` / `with_roots` constructors) but belongs in its own change — happy to send it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
