### PR TITLE
fix: make semantic fast resume bounded and recover zero-norm hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ tempfile = "3.27.0"
 wait-timeout = "0.2.1"
 rmp-serde = "1.3.1"  # MessagePack for binary metadata serialization (Opt 3.1)
 toml = "1.1.2"
+# Bounded semantic candidate selection is read-only C-SQLite; canonical replay
+# and every write remain on FrankenSQLite.
+rusqlite = { version = "0.39.0", features = ["bundled", "modern_sqlite"] }
 directories = "6.0.0"
 which = "8.0.2"
 shell-words = "1.1.1"
@@ -186,9 +189,6 @@ arbitrary = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.34"
 rand = "0.10"
 rand_chacha = "0.10"
-# rusqlite is retained only for C-SQLite interop fixtures in tests; production
-# storage and historical salvage paths use frankensqlite.
-rusqlite = { version = "0.39.0", features = ["bundled", "modern_sqlite"] }
 # The manifest-policy build gate requires this explicit dev entry for compat
 # fixture assertions, even though production also uses the same pinned crate.
 fsqlite-types = { version = "0.1.19", package = "fsqlite-types", git = "https://github.com/Dicklesworthstone/frankensqlite", rev = "2351c6c52b9e5fdba6a413865415db0452e660ef" }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -10601,6 +10601,16 @@ pub(crate) fn load_active_lexical_rebuild_pipeline_runtime(
     Ok(Some(state.runtime))
 }
 
+/// Compute the canonical content fingerprint from an already-open storage handle.
+///
+/// Resumable semantic backfill owns such a handle for its complete bounded run.
+/// Reusing it prevents a second FrankenSQLite open and archive scan solely for
+/// fingerprinting before every checkpoint.
+pub(crate) fn lexical_storage_fingerprint_from_storage(storage: &FrankenStorage) -> Result<String> {
+    let total_conversations = count_total_conversations_exact(storage)?;
+    lexical_rebuild_content_fingerprint(storage, total_conversations)
+}
+
 pub(crate) fn lexical_storage_fingerprint_for_db(db_path: &Path) -> Result<String> {
     lexical_rebuild_storage_fingerprint(db_path)
 }

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -884,6 +884,66 @@ fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
     Ok(count)
 }
 
+/// Return the exact next candidate prefix through bounded parent probes when
+/// the first parent page is dense enough. Sparse archives retain the global
+/// cursor fallback below, avoiding a semantic correctness trade-off.
+fn try_fetch_dense_semantic_candidate_conversation_ids(
+    storage: &FrankenStorage,
+    after_conversation_id: i64,
+    after_message_id: i64,
+    max_candidates: usize,
+) -> Result<Option<(Vec<i64>, usize)>> {
+    let page_size = max_candidates.saturating_mul(4).clamp(256, 4_096);
+    let page_size_i64 = i64::try_from(page_size).unwrap_or(i64::MAX);
+    let page: Vec<i64> = storage
+        .raw()
+        .query_map_collect(
+            "SELECT id FROM conversations
+             WHERE id > ?1
+             ORDER BY id ASC
+             LIMIT ?2",
+            &[
+                ParamValue::from(after_conversation_id),
+                ParamValue::from(page_size_i64),
+            ],
+            |row| {
+                let conversation_id: i64 = row.get_typed(0)?;
+                Ok(conversation_id)
+            },
+        )
+        .with_context(|| {
+            format!(
+                "listing dense semantic candidate page after conversation {after_conversation_id}"
+            )
+        })?;
+    if page.is_empty() {
+        return Ok(Some((Vec::new(), 0)));
+    }
+
+    let page_len = page.len();
+    let mut selected = Vec::with_capacity(max_candidates);
+    let mut rows_scanned = 0usize;
+    for conversation_id in page {
+        rows_scanned = rows_scanned.saturating_add(1);
+        if semantic_conversation_has_message_after(
+            storage,
+            conversation_id,
+            Some(after_message_id),
+        )? {
+            selected.push(conversation_id);
+            if selected.len() >= max_candidates {
+                return Ok(Some((selected, rows_scanned)));
+            }
+        }
+    }
+
+    if page_len < page_size {
+        Ok(Some((selected, rows_scanned)))
+    } else {
+        Ok(None)
+    }
+}
+
 fn fetch_bounded_semantic_candidate_conversation_ids(
     storage: &FrankenStorage,
     after_conversation_id: i64,
@@ -892,6 +952,15 @@ fn fetch_bounded_semantic_candidate_conversation_ids(
 ) -> Result<(Vec<i64>, usize)> {
     let max_candidates = max_candidates.max(1);
     if let Some(after_message_id) = after_message_id {
+        if let Some(fast_path) = try_fetch_dense_semantic_candidate_conversation_ids(
+            storage,
+            after_conversation_id,
+            after_message_id,
+            max_candidates,
+        )? {
+            return Ok(fast_path);
+        }
+
         // Resume from the canonical global message cursor, not from the much
         // wider parent-table gap.  The previous implementation paged
         // `conversations` and executed one prepared message probe for every

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -948,11 +948,11 @@ fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
     Ok(count)
 }
 
-/// Return the exact next candidate prefix through bounded parent probes when
-/// the first parent page is dense enough. Each normal parent resolves its
-/// single tail row through the canonical `(conversation_id, idx)` key instead
-/// of scanning a conversation history with an incompatible `id > cursor`
-/// predicate. Sparse or legacy archives retain the global cursor fallback.
+/// Return the exact next candidate prefix through one bounded indexed parent
+/// page query. Normal archives resolve each page's tail through the canonical
+/// `(conversation_id, idx)` key in that single query; this avoids retaining
+/// FrankenSQLite state for a separate tail lookup per parent. Sparse or legacy
+/// archives retain the global cursor fallback.
 fn try_fetch_dense_semantic_candidate_conversation_ids(
     storage: &FrankenStorage,
     after_conversation_id: i64,
@@ -961,18 +961,34 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
 ) -> Result<Option<(Vec<i64>, usize)>> {
     let page_size = max_candidates.saturating_mul(4).clamp(256, 4_096);
     let page_size_i64 = i64::try_from(page_size).unwrap_or(i64::MAX);
-    let page: Vec<(i64, Option<i64>)> = storage
+    let page: Vec<(i64, Option<i64>, Option<i64>)> = storage
         .raw()
         .query_map_collect(
-            "SELECT id, last_message_idx FROM conversations
-             WHERE id > ?1
-             ORDER BY id ASC
-             LIMIT ?2",
+            "SELECT page.id,
+                    COALESCE(page.last_message_idx, tails.last_message_idx),
+                    tail_message.id
+             FROM (
+                 SELECT id, last_message_idx
+                 FROM conversations
+                 WHERE id > ?1
+                 ORDER BY id ASC
+                 LIMIT ?2
+             ) AS page
+             LEFT JOIN conversation_tail_state AS tails
+                    ON tails.conversation_id = page.id
+             LEFT JOIN messages AS tail_message
+                    INDEXED BY sqlite_autoindex_messages_1
+                    ON tail_message.conversation_id = page.id
+                   AND tail_message.idx = COALESCE(
+                       page.last_message_idx,
+                       tails.last_message_idx
+                   )
+             ORDER BY page.id ASC",
             &[
                 ParamValue::from(after_conversation_id),
                 ParamValue::from(page_size_i64),
             ],
-            |row| Ok((row.get_typed(0)?, row.get_typed(1)?)),
+            |row| Ok((row.get_typed(0)?, row.get_typed(1)?, row.get_typed(2)?)),
         )
         .with_context(|| {
             format!(
@@ -986,15 +1002,11 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
     let page_len = page.len();
     let mut selected = Vec::with_capacity(max_candidates);
     let mut rows_scanned = 0usize;
-    for (conversation_id, legacy_last_message_idx) in page {
+    for (conversation_id, tail_idx, tail_message_id) in page {
         rows_scanned = rows_scanned.saturating_add(1);
-        let has_newer_message = match semantic_conversation_tail_message_id(
-            storage,
-            conversation_id,
-            legacy_last_message_idx,
-        )? {
-            Some(tail_message_id) => tail_message_id > after_message_id,
-            None => semantic_conversation_has_message_after(
+        let has_newer_message = match (tail_idx, tail_message_id) {
+            (Some(_), Some(tail_message_id)) => tail_message_id > after_message_id,
+            (None, _) | (_, None) => semantic_conversation_has_message_after(
                 storage,
                 conversation_id,
                 Some(after_message_id),

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -17,6 +17,7 @@ use frankensqlite::{
 };
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rayon::prelude::*;
+use rusqlite::{Connection as NativeSqliteConnection, OpenFlags};
 
 use crate::indexer::memoization::{
     ContentAddressedMemoCache, MemoCacheAuditRecord, MemoContentHash, MemoKey, MemoLookup,
@@ -840,68 +841,22 @@ fn semantic_conversation_has_message_after(
     Ok(has_message)
 }
 
-/// Return the canonical tail message id for one conversation without scanning
-/// its full message history. Normal archives maintain `last_message_idx` on
-/// the parent row; the compact tail table is the compatible fallback for older
-/// rows. The unique `(conversation_id, idx)` key then resolves exactly one row.
-fn semantic_conversation_tail_message_id(
+/// Selection is a bounded, read-only operation. Run it through native SQLite
+/// so a hostile FrankenSQLite query plan cannot retain archive-sized state;
+/// canonical replay and all writes remain on FrankenStorage.
+fn native_semantic_selection_connection(
     storage: &FrankenStorage,
-    conversation_id: i64,
-    legacy_last_message_idx: Option<i64>,
-) -> Result<Option<i64>> {
-    let tail_idx = match legacy_last_message_idx {
-        Some(last_message_idx) => Some(last_message_idx),
-        None => storage
-            .raw()
-            .query_map_collect(
-                "SELECT last_message_idx
-                 FROM conversation_tail_state
-                 WHERE conversation_id = ?1 AND last_message_idx IS NOT NULL",
-                &[ParamValue::from(conversation_id)],
-                |row| row.get_typed(0),
-            )
-            .with_context(|| {
-                format!("looking up semantic tail metadata for conversation {conversation_id}")
-            })?
-            .into_iter()
-            .next(),
-    };
-    let Some(tail_idx) = tail_idx else {
-        return Ok(None);
-    };
-
-    let params = [
-        ParamValue::from(conversation_id),
-        ParamValue::from(tail_idx),
-    ];
-    let indexed_probe = "SELECT id
-                         FROM messages INDEXED BY sqlite_autoindex_messages_1
-                         WHERE conversation_id = ?1 AND idx = ?2
-                         LIMIT 1";
-    let fallback_probe = "SELECT id
-                          FROM messages
-                          WHERE conversation_id = ?1 AND idx = ?2
-                          LIMIT 1";
-    let tail_ids: Vec<i64> = storage
-        .raw()
-        .query_map_collect(indexed_probe, &params, |row| row.get_typed(0))
-        .or_else(|err| {
-            if !err
-                .to_string()
-                .contains("no such index: sqlite_autoindex_messages_1")
-            {
-                return Err(err);
-            }
-            storage
-                .raw()
-                .query_map_collect(fallback_probe, &params, |row| row.get_typed(0))
-        })
+) -> Result<NativeSqliteConnection> {
+    let db_path = storage
+        .database_path()
+        .with_context(|| "resolving canonical database path for native semantic selection")?;
+    NativeSqliteConnection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| {
             format!(
-                "probing semantic tail message for conversation {conversation_id} at idx {tail_idx}"
+                "opening native read-only semantic selector at {}",
+                db_path.display()
             )
-        })?;
-    Ok(tail_ids.into_iter().next())
+        })
 }
 
 fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
@@ -948,11 +903,10 @@ fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
     Ok(count)
 }
 
-/// Return the exact next candidate prefix through one bounded indexed parent
-/// page query. Normal archives resolve each page's tail through the canonical
-/// `(conversation_id, idx)` key in that single query; this avoids retaining
-/// FrankenSQLite state for a separate tail lookup per parent. Sparse or legacy
-/// archives retain the global cursor fallback.
+/// Return the exact next candidate prefix through a bounded native-SQLite
+/// parent-page query. Canonical replay and all writes remain on
+/// FrankenStorage; only this read-only selector crosses the compatibility
+/// boundary. Sparse or legacy archives retain the global cursor fallback.
 fn try_fetch_dense_semantic_candidate_conversation_ids(
     storage: &FrankenStorage,
     after_conversation_id: i64,
@@ -961,9 +915,9 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
 ) -> Result<Option<(Vec<i64>, usize)>> {
     let page_size = max_candidates.saturating_mul(4).clamp(256, 4_096);
     let page_size_i64 = i64::try_from(page_size).unwrap_or(i64::MAX);
-    let page: Vec<(i64, Option<i64>, Option<i64>)> = storage
-        .raw()
-        .query_map_collect(
+    let native = native_semantic_selection_connection(storage)?;
+    let mut statement = native
+        .prepare(
             "SELECT page.id,
                     COALESCE(page.last_message_idx, tails.last_message_idx),
                     tail_message.id
@@ -984,15 +938,21 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
                        tails.last_message_idx
                    )
              ORDER BY page.id ASC",
-            &[
-                ParamValue::from(after_conversation_id),
-                ParamValue::from(page_size_i64),
-            ],
-            |row| Ok((row.get_typed(0)?, row.get_typed(1)?, row.get_typed(2)?)),
         )
         .with_context(|| {
             format!(
                 "listing dense semantic candidate page after conversation {after_conversation_id}"
+            )
+        })?;
+    let page: Vec<(i64, Option<i64>, Option<i64>)> = statement
+        .query_map(
+            rusqlite::params![after_conversation_id, page_size_i64],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?
+        .collect::<std::result::Result<_, _>>()
+        .with_context(|| {
+            format!(
+                "materializing bounded native semantic candidate page after conversation {after_conversation_id}"
             )
         })?;
     if page.is_empty() {
@@ -1006,11 +966,17 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
         rows_scanned = rows_scanned.saturating_add(1);
         let has_newer_message = match (tail_idx, tail_message_id) {
             (Some(_), Some(tail_message_id)) => tail_message_id > after_message_id,
-            (None, _) | (_, None) => semantic_conversation_has_message_after(
-                storage,
-                conversation_id,
-                Some(after_message_id),
-            )?,
+            (None, _) | (_, None) => {
+                native.query_row(
+                    "SELECT EXISTS(
+                     SELECT 1
+                     FROM messages INDEXED BY sqlite_autoindex_messages_1
+                     WHERE conversation_id = ?1 AND id > ?2
+                 )",
+                    rusqlite::params![conversation_id, after_message_id],
+                    |row| row.get::<_, i64>(0),
+                )? != 0
+            }
         };
         if has_newer_message {
             selected.push(conversation_id);
@@ -1045,59 +1011,53 @@ fn fetch_bounded_semantic_candidate_conversation_ids(
         }
 
         // Resume from the canonical global message cursor, not from the much
-        // wider parent-table gap.  The previous implementation paged
-        // `conversations` and executed one prepared message probe for every
-        // parent.  A legitimate sparse checkpoint in #348 crossed 6,668
-        // ineligible parents and retained more than 2 GiB before finding two
-        // candidates.
-        //
-        // `messages.id` is the canonical INTEGER PRIMARY KEY cursor.  Force a
-        // table/rowid traversal so FrankenSQLite can stream every eligible
-        // post-cursor message through one statement.  A bounded BTreeSet keeps
-        // only the smallest `max_candidates` conversation IDs.  This final
-        // reconciliation is essential: messages may be appended to older
-        // conversations, so global message-id order is not necessarily
-        // conversation-id order, while the durable conversation checkpoint
-        // must advance in ascending order without skipping an older candidate.
+        // wider parent-table gap. This sparse compatibility path remains
+        // native and read-only for the same reason as the dense prefix: it
+        // must stream rows without retaining archive-sized FrankenSQLite state.
+        // A bounded BTreeSet keeps only the smallest `max_candidates`
+        // conversation IDs while canonical replay and all writes stay on
+        // FrankenStorage.
         let mut selected = BTreeSet::new();
         let mut rows_scanned = 0_usize;
-        storage
-            .raw()
-            .query_with_params_for_each(
+        let native = native_semantic_selection_connection(storage)?;
+        let mut statement = native
+            .prepare(
                 "SELECT conversation_id
-                 FROM messages NOT INDEXED
+                 FROM messages
                  WHERE id > ?1 AND conversation_id > ?2",
-                &[
-                    SqliteValue::from(after_message_id),
-                    SqliteValue::from(after_conversation_id),
-                ],
-                |row| {
-                    let conversation_id: i64 = row.get_typed(0)?;
-                    rows_scanned = rows_scanned.saturating_add(1);
-                    if selected.contains(&conversation_id) {
-                        return Ok(());
-                    }
-                    if selected.len() < max_candidates {
-                        selected.insert(conversation_id);
-                        return Ok(());
-                    }
-                    if selected
-                        .last()
-                        .is_some_and(|largest| conversation_id < *largest)
-                    {
-                        selected.insert(conversation_id);
-                        if let Some(largest) = selected.last().copied() {
-                            selected.remove(&largest);
-                        }
-                    }
-                    Ok(())
-                },
             )
             .with_context(|| {
                 format!(
-                    "streaming semantic candidates after conversation {after_conversation_id} and message {after_message_id}"
+                    "preparing native sparse semantic selector after conversation {after_conversation_id} and message {after_message_id}"
                 )
             })?;
+        let mut rows = statement
+            .query(rusqlite::params![after_message_id, after_conversation_id])
+            .with_context(|| {
+                format!(
+                    "streaming native semantic candidates after conversation {after_conversation_id} and message {after_message_id}"
+                )
+            })?;
+        while let Some(row) = rows.next()? {
+            let conversation_id: i64 = row.get(0)?;
+            rows_scanned = rows_scanned.saturating_add(1);
+            if selected.contains(&conversation_id) {
+                continue;
+            }
+            if selected.len() < max_candidates {
+                selected.insert(conversation_id);
+                continue;
+            }
+            if selected
+                .last()
+                .is_some_and(|largest| conversation_id < *largest)
+            {
+                selected.insert(conversation_id);
+                if let Some(largest) = selected.last().copied() {
+                    selected.remove(&largest);
+                }
+            }
+        }
         return Ok((selected.into_iter().collect(), rows_scanned));
     }
 

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -840,6 +840,70 @@ fn semantic_conversation_has_message_after(
     Ok(has_message)
 }
 
+/// Return the canonical tail message id for one conversation without scanning
+/// its full message history. Normal archives maintain `last_message_idx` on
+/// the parent row; the compact tail table is the compatible fallback for older
+/// rows. The unique `(conversation_id, idx)` key then resolves exactly one row.
+fn semantic_conversation_tail_message_id(
+    storage: &FrankenStorage,
+    conversation_id: i64,
+    legacy_last_message_idx: Option<i64>,
+) -> Result<Option<i64>> {
+    let tail_idx = match legacy_last_message_idx {
+        Some(last_message_idx) => Some(last_message_idx),
+        None => storage
+            .raw()
+            .query_map_collect(
+                "SELECT last_message_idx
+                 FROM conversation_tail_state
+                 WHERE conversation_id = ?1 AND last_message_idx IS NOT NULL",
+                &[ParamValue::from(conversation_id)],
+                |row| row.get_typed(0),
+            )
+            .with_context(|| {
+                format!("looking up semantic tail metadata for conversation {conversation_id}")
+            })?
+            .into_iter()
+            .next(),
+    };
+    let Some(tail_idx) = tail_idx else {
+        return Ok(None);
+    };
+
+    let params = [
+        ParamValue::from(conversation_id),
+        ParamValue::from(tail_idx),
+    ];
+    let indexed_probe = "SELECT id
+                         FROM messages INDEXED BY sqlite_autoindex_messages_1
+                         WHERE conversation_id = ?1 AND idx = ?2
+                         LIMIT 1";
+    let fallback_probe = "SELECT id
+                          FROM messages
+                          WHERE conversation_id = ?1 AND idx = ?2
+                          LIMIT 1";
+    let tail_ids: Vec<i64> = storage
+        .raw()
+        .query_map_collect(indexed_probe, &params, |row| row.get_typed(0))
+        .or_else(|err| {
+            if !err
+                .to_string()
+                .contains("no such index: sqlite_autoindex_messages_1")
+            {
+                return Err(err);
+            }
+            storage
+                .raw()
+                .query_map_collect(fallback_probe, &params, |row| row.get_typed(0))
+        })
+        .with_context(|| {
+            format!(
+                "probing semantic tail message for conversation {conversation_id} at idx {tail_idx}"
+            )
+        })?;
+    Ok(tail_ids.into_iter().next())
+}
+
 fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
     // `conversation_tail_state.last_message_idx` is the maintained, schema-v18
     // hot cache for every normal non-empty conversation. Merge that compact
@@ -885,8 +949,10 @@ fn total_semantic_conversations(storage: &FrankenStorage) -> Result<u64> {
 }
 
 /// Return the exact next candidate prefix through bounded parent probes when
-/// the first parent page is dense enough. Sparse archives retain the global
-/// cursor fallback below, avoiding a semantic correctness trade-off.
+/// the first parent page is dense enough. Each normal parent resolves its
+/// single tail row through the canonical `(conversation_id, idx)` key instead
+/// of scanning a conversation history with an incompatible `id > cursor`
+/// predicate. Sparse or legacy archives retain the global cursor fallback.
 fn try_fetch_dense_semantic_candidate_conversation_ids(
     storage: &FrankenStorage,
     after_conversation_id: i64,
@@ -895,10 +961,10 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
 ) -> Result<Option<(Vec<i64>, usize)>> {
     let page_size = max_candidates.saturating_mul(4).clamp(256, 4_096);
     let page_size_i64 = i64::try_from(page_size).unwrap_or(i64::MAX);
-    let page: Vec<i64> = storage
+    let page: Vec<(i64, Option<i64>)> = storage
         .raw()
         .query_map_collect(
-            "SELECT id FROM conversations
+            "SELECT id, last_message_idx FROM conversations
              WHERE id > ?1
              ORDER BY id ASC
              LIMIT ?2",
@@ -906,10 +972,7 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
                 ParamValue::from(after_conversation_id),
                 ParamValue::from(page_size_i64),
             ],
-            |row| {
-                let conversation_id: i64 = row.get_typed(0)?;
-                Ok(conversation_id)
-            },
+            |row| Ok((row.get_typed(0)?, row.get_typed(1)?)),
         )
         .with_context(|| {
             format!(
@@ -923,13 +986,21 @@ fn try_fetch_dense_semantic_candidate_conversation_ids(
     let page_len = page.len();
     let mut selected = Vec::with_capacity(max_candidates);
     let mut rows_scanned = 0usize;
-    for conversation_id in page {
+    for (conversation_id, legacy_last_message_idx) in page {
         rows_scanned = rows_scanned.saturating_add(1);
-        if semantic_conversation_has_message_after(
+        let has_newer_message = match semantic_conversation_tail_message_id(
             storage,
             conversation_id,
-            Some(after_message_id),
+            legacy_last_message_idx,
         )? {
+            Some(tail_message_id) => tail_message_id > after_message_id,
+            None => semantic_conversation_has_message_after(
+                storage,
+                conversation_id,
+                Some(after_message_id),
+            )?,
+        };
+        if has_newer_message {
             selected.push(conversation_id);
             if selected.len() >= max_candidates {
                 return Ok(Some((selected, rows_scanned)));

--- a/src/indexer/semantic.rs
+++ b/src/indexer/semantic.rs
@@ -2724,13 +2724,14 @@ impl SemanticIndexer {
         data_dir: &Path,
     ) -> Result<usize> {
         let index_path = vector_index_path(data_dir, self.embedder_id());
-        self.append_to_index_path(embedded_messages, &index_path)
+        self.append_to_index_path(embedded_messages, &index_path, true)
     }
 
     fn append_to_index_path(
         &self,
         embedded_messages: impl IntoIterator<Item = EmbeddedMessage>,
         index_path: &Path,
+        compact_when_needed: bool,
     ) -> Result<usize> {
         let mut index = FsVectorIndex::open(index_path)
             .map_err(|err| anyhow::anyhow!("open fsvi index for append: {err}"))?;
@@ -2769,7 +2770,7 @@ impl SemanticIndexer {
             .append_batch(&entries)
             .map_err(|err| anyhow::anyhow!("append_batch: {err}"))?;
 
-        if index.needs_compaction() {
+        if compact_when_needed && index.needs_compaction() {
             index
                 .compact()
                 .map_err(|err| anyhow::anyhow!("compaction: {err}"))?;
@@ -3017,7 +3018,11 @@ impl SemanticIndexer {
         resume_existing: bool,
     ) -> Result<FsVectorIndex> {
         if resume_existing && staging_path.exists() {
-            self.append_to_index_path(embedded_messages, staging_path)?;
+            // A resumable backfill deliberately keeps its growing delta in the
+            // staging WAL. Compacting after a small checkpoint rewrites every
+            // prior vector and turns the bounded path into O(corpus-size) work
+            // per checkpoint. The final publish path compacts once, atomically.
+            self.append_to_index_path(embedded_messages, staging_path, false)?;
             FsVectorIndex::open(staging_path)
                 .map_err(|err| anyhow::anyhow!("open staged semantic index failed: {err}"))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2268,6 +2268,9 @@ pub enum ModelsCommand {
         /// Maximum canonical conversations to process in this batch
         #[arg(long, default_value_t = 64)]
         batch_conversations: usize,
+        /// Maximum checkpoints to process in one bounded process (default: one)
+        #[arg(long, default_value_t = 1)]
+        max_batches: usize,
         /// Apply idle/load scheduler gates before running this batch
         #[arg(long, visible_alias = "background")]
         scheduled: bool,
@@ -103255,6 +103258,7 @@ fn run_models_command(cmd: ModelsCommand, cli: &Cli) -> CliResult<()> {
             tier,
             embedder,
             batch_conversations,
+            max_batches,
             scheduled,
             data_dir,
             db,
@@ -103265,6 +103269,7 @@ fn run_models_command(cmd: ModelsCommand, cli: &Cli) -> CliResult<()> {
                 &tier,
                 embedder.as_deref(),
                 batch_conversations,
+                max_batches,
                 scheduled,
                 data_dir,
                 db.or_else(|| cli.db.clone()),
@@ -104787,6 +104792,7 @@ fn run_models_backfill(
     tier_raw: &str,
     embedder_override: Option<&str>,
     batch_conversations: usize,
+    max_batches: usize,
     scheduled: bool,
     data_dir_override: Option<PathBuf>,
     db_override: Option<PathBuf>,
@@ -104808,6 +104814,16 @@ fn run_models_backfill(
             kind: CliErrorKind::Usage.kind_str(),
             message: "--batch-conversations must be greater than zero".to_string(),
             hint: Some("Use a small positive batch such as --batch-conversations 64".into()),
+            retryable: false,
+        });
+    }
+
+    if max_batches == 0 {
+        return Err(CliError {
+            code: 2,
+            kind: CliErrorKind::Usage.kind_str(),
+            message: "--max-batches must be greater than zero".to_string(),
+            hint: Some("Use a positive bound such as --max-batches 16".into()),
             retryable: false,
         });
     }
@@ -104852,7 +104868,7 @@ fn run_models_backfill(
         let signals = SemanticBackfillSchedulerSignals::from_env();
         Some(semantic_backfill_scheduler_decision(
             &policy,
-            batch_conversations,
+            max_batches,
             &signals,
         ))
     } else {
@@ -104910,8 +104926,15 @@ fn run_models_backfill(
             decision.scheduled_batch_conversations
         });
 
-    let db_fingerprint =
-        crate::indexer::lexical_storage_fingerprint_for_db(&db_path).map_err(|e| CliError {
+    let storage = FrankenStorage::open(&db_path).map_err(|e| CliError {
+        code: 5,
+        kind: CliErrorKind::Storage.kind_str(),
+        message: format!("Failed to open cass database {}: {e}", db_path.display()),
+        hint: Some("Run 'cass health --json' to inspect the archive database".into()),
+        retryable: true,
+    })?;
+    let db_fingerprint = crate::indexer::lexical_storage_fingerprint_from_storage(&storage)
+        .map_err(|e| CliError {
             code: 5,
             kind: CliErrorKind::StorageFingerprint.kind_str(),
             message: format!(
@@ -104924,13 +104947,6 @@ fn run_models_backfill(
             ),
             retryable: true,
         })?;
-    let storage = FrankenStorage::open(&db_path).map_err(|e| CliError {
-        code: 5,
-        kind: CliErrorKind::Storage.kind_str(),
-        message: format!("Failed to open cass database {}: {e}", db_path.display()),
-        hint: Some("Run 'cass health --json' to inspect the archive database".into()),
-        retryable: true,
-    })?;
     let mut manifest = SemanticManifest::load_or_default(&data_dir).map_err(|e| CliError {
         code: 5,
         kind: CliErrorKind::SemanticManifest.kind_str(),
@@ -104969,28 +104985,36 @@ fn run_models_backfill(
         tier.as_str(),
         indexer.embedder_id(),
     );
-    let outcome = indexer
-        .run_capped_backfill_from_storage_with_sink(
-            &storage,
-            &data_dir,
-            &mut manifest,
-            SemanticBackfillStoragePlan {
-                tier,
-                db_fingerprint,
-                model_revision,
-                max_conversations: effective_batch_conversations,
-            },
-            &progress_sink,
-        )
-        .map_err(|e| CliError {
-            code: 5,
-            kind: CliErrorKind::SemanticBackfill.kind_str(),
-            message: format!("Semantic backfill failed: {e}"),
-            hint: Some(
-                "Retry the command; resumable checkpoints are kept in the semantic manifest".into(),
-            ),
-            retryable: true,
-        })?;
+    let mut batches_run = 0usize;
+    let outcome = loop {
+        let outcome = indexer
+            .run_capped_backfill_from_storage_with_sink(
+                &storage,
+                &data_dir,
+                &mut manifest,
+                SemanticBackfillStoragePlan {
+                    tier,
+                    db_fingerprint: db_fingerprint.clone(),
+                    model_revision: model_revision.clone(),
+                    max_conversations: effective_batch_conversations,
+                },
+                &progress_sink,
+            )
+            .map_err(|e| CliError {
+                code: 5,
+                kind: CliErrorKind::SemanticBackfill.kind_str(),
+                message: format!("Semantic backfill failed: {e}"),
+                hint: Some(
+                    "Retry the command; resumable checkpoints are kept in the semantic manifest"
+                        .into(),
+                ),
+                retryable: true,
+            })?;
+        batches_run = batches_run.saturating_add(1);
+        if outcome.published || !outcome.checkpoint_saved || batches_run >= max_batches {
+            break outcome;
+        }
+    };
 
     let progress_pct = outcome.progress_pct();
     let status = if outcome.published {
@@ -105000,8 +105024,12 @@ fn run_models_backfill(
     } else {
         "idle"
     };
+    let bounded_run_complete =
+        outcome.checkpoint_saved && !outcome.published && batches_run >= max_batches;
     let next_step = if outcome.published {
         "semantic tier is ready"
+    } else if bounded_run_complete {
+        "bounded multi-batch run reached its limit; rerun the same command to continue the resumable backfill"
     } else if outcome.checkpoint_saved {
         "rerun the same command to continue the resumable backfill"
     } else {
@@ -105034,6 +105062,8 @@ fn run_models_backfill(
                 "batch_conversations_limit": effective_batch_conversations,
                 "requested_batch_conversations_limit": batch_conversations,
                 "scheduler": scheduler_decision,
+                "max_batches": max_batches,
+                "batches_run": batches_run,
                 "embedded_docs": outcome.embedded_docs,
                 "conversations_processed": outcome.conversations_processed,
                 "total_conversations": outcome.total_conversations,

--- a/src/search/hash_embedder.rs
+++ b/src/search/hash_embedder.rs
@@ -123,7 +123,7 @@ impl Embedder for HashEmbedder {
 
         let tokens = Self::tokenize(text);
 
-        // Preserve cass legacy behavior for low-signal inputs.
+        // Preserve cass legacy behavior for tokenless low-signal inputs.
         if tokens.is_empty() {
             return Ok(self.uniform_fallback());
         }
@@ -141,6 +141,12 @@ impl Embedder for HashEmbedder {
                     embedding.len()
                 ))),
             });
+        }
+        // Feature hashing can exactly cancel two or more token contributions
+        // in a dimension. Frankensearch correctly refuses zero-norm vectors,
+        // so use the same deterministic nonzero fallback as tokenless input.
+        if embedding.iter().all(|value| *value == 0.0) {
+            return Ok(self.uniform_fallback());
         }
         Ok(embedding)
     }
@@ -252,6 +258,31 @@ mod tests {
             (norm - 1.0).abs() < 1e-5,
             "L2 norm should be ~1.0, got {norm}"
         );
+    }
+
+    #[test]
+    fn test_hash_embedder_cancellation_uses_nonzero_fallback() {
+        let embedder = HashEmbedder::new(1);
+        let mut positive = None;
+        let mut negative = None;
+        for index in 0..1024 {
+            let token = format!("token{index}");
+            let raw = embedder.delegate.embed_sync(&token);
+            if raw[0] > 0.0 {
+                positive = Some(token);
+            } else if raw[0] < 0.0 {
+                negative = Some(token);
+            }
+            if positive.is_some() && negative.is_some() {
+                break;
+            }
+        }
+        let positive = positive.expect("fixture should find a positive hash feature");
+        let negative = negative.expect("fixture should find a negative hash feature");
+        let text = format!("{positive} {negative}");
+        let embedding = embedder.embed_sync(&text).unwrap();
+
+        assert_eq!(embedding, vec![1.0]);
     }
 
     #[test]


### PR DESCRIPTION
Resolves #383.

The semantic resume selector could make FrankenSQLite materialize tail queries pathologically. This moves only the bounded, read-only selection/count work to native SQLite; canonical replay and every write remain on FrankenStorage. It also defers staging compaction until final publication and falls back to the existing deterministic unit vector when hash-feature cancellation produces a zero-norm embedding.

Validation:

- `cargo fmt --check`
- Release candidate live canary through the former failure: selection in 8 ms at 55 MiB RSS; 5,039 embeddings staged and checkpoint saved in 8.49 s at 277 MiB peak RSS
- Multiple bounded timer-fired cycles completed after the canary
