### PR TITLE
fix(search): keep semantic ANN independent of lexical repair

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25347,17 +25347,26 @@ fn run_cli_search(
         return Ok(());
     }
 
-    let search_self_heal = ensure_lexical_assets_for_search(
-        &data_dir,
-        &db_path,
-        &index_path,
-        timeout_ms,
-        start_time,
-        dry_run,
-        // #287: robot callers get a bounded degraded refusal (stable reason
-        // code) instead of a silent multi-minute inline lexical rebuild.
-        effective_robot.is_some(),
-    )?;
+    // A deliberately semantic-only request does not consult Tantivy.  In
+    // particular, `--mode semantic --approximate` must be able to use an
+    // already-attested HNSW graph even when the independently-maintained
+    // lexical checkpoint needs repair.  Running lexical self-heal here can
+    // otherwise turn a read query into a long rebuild before ANN is reached.
+    let search_self_heal = if matches!(mode, Some(SearchMode::Semantic)) {
+        SearchLexicalSelfHeal::skipped()
+    } else {
+        ensure_lexical_assets_for_search(
+            &data_dir,
+            &db_path,
+            &index_path,
+            timeout_ms,
+            start_time,
+            dry_run,
+            // #287: robot callers get a bounded degraded refusal (stable reason
+            // code) instead of a silent multi-minute inline lexical rebuild.
+            effective_robot.is_some(),
+        )?
+    };
     if search_self_heal.action != "skipped" {
         tracing::info!(
             action = search_self_heal.action,


### PR DESCRIPTION
An explicit semantic-only query does not consume Tantivy, but `run_cli_search` currently ran lexical self-heal before it could initialize the semantic path. On a large valid archive whose lexical checkpoint needs repair, `cass search --mode semantic --approximate` therefore entered an unrelated lexical rebuild/lock wait and never reached HNSW.

This keeps the existing repair behavior for default hybrid and lexical requests. It skips self-heal only for explicit `--mode semantic`, allowing an already-attested ANN graph to remain usable independently of lexical maintenance.

Validation: `git diff --check` passed. The repository formatter reports an existing unrelated format delta in `src/search/query.rs`; this patch itself is formatted.