### PR TITLE
fix(tui): honor global --db location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6696,7 +6696,7 @@ async fn execute_cli(
 
     match &command {
         Commands::Tui { data_dir, .. } => {
-            let log_dir = data_dir.clone().unwrap_or_else(default_data_dir);
+            let log_dir = resolve_data_dir(data_dir, cli.db.as_ref());
             std::fs::create_dir_all(&log_dir).ok();
 
             let file_appender = tracing_appender::rolling::daily(&log_dir, "cass.log");
@@ -6735,8 +6735,13 @@ async fn execute_cli(
                 refresh,
             } = command.clone()
             {
+                let tui_data_dir = resolve_data_dir(&data_dir, cli.db.as_ref());
+                let tui_db_path = cli
+                    .db
+                    .clone()
+                    .unwrap_or_else(|| tui_data_dir.join("agent_search.db"));
                 if refresh {
-                    refresh_index_inline(cli.db.clone(), data_dir.clone());
+                    refresh_index_inline(cli.db.clone(), Some(tui_data_dir.clone()));
                 }
                 info!(once, inline, ui_height, %anchor, record_macro = ?record_macro, play_macro = ?play_macro, "launching ftui runtime");
 
@@ -6754,7 +6759,6 @@ async fn execute_cli(
                     None
                 };
 
-                let tui_data_dir = data_dir.clone().unwrap_or_else(default_data_dir);
                 if reset_state {
                     let state_path = tui_data_dir.join("tui_state.json");
                     match std::fs::remove_file(&state_path) {
@@ -6782,20 +6786,24 @@ async fn execute_cli(
                     once && !inline && !stdout_is_tty && dotenvy::var("TUI_HEADLESS").is_ok();
 
                 if non_tty_headless_once {
-                    prepare_headless_once_tui_artifacts(&tui_data_dir, asciicast.as_deref())
-                        .map_err(|e| CliError {
-                            code: 9,
-                            kind: CliErrorKind::TuiHeadlessOnce.kind_str(),
-                            message: format!(
-                                "headless --once TUI bootstrap failed for {}: {e}",
-                                tui_data_dir.display()
-                            ),
-                            hint: Some(
-                                "Ensure the data directory is writable and retry the command."
-                                    .to_string(),
-                            ),
-                            retryable: false,
-                        })?;
+                    prepare_headless_once_tui_artifacts(
+                        &tui_data_dir,
+                        &tui_db_path,
+                        asciicast.as_deref(),
+                    )
+                    .map_err(|e| CliError {
+                        code: 9,
+                        kind: CliErrorKind::TuiHeadlessOnce.kind_str(),
+                        message: format!(
+                            "headless --once TUI bootstrap failed for {}: {e}",
+                            tui_data_dir.display()
+                        ),
+                        hint: Some(
+                            "Ensure the data directory is writable and retry the command."
+                                .to_string(),
+                        ),
+                        retryable: false,
+                    })?;
                     info!(
                         data_dir = %tui_data_dir.display(),
                         asciicast = ?asciicast,
@@ -6809,7 +6817,12 @@ async fn execute_cli(
                     let run_result = if let Some(path) = asciicast {
                         tui_asciicast::run_tui_with_asciicast(&path, !once)
                     } else {
-                        ui::app::run_tui_ftui(inline_config, macro_config, Some(tui_data_dir))
+                        ui::app::run_tui_ftui(
+                            inline_config,
+                            macro_config,
+                            Some(tui_data_dir),
+                            Some(tui_db_path),
+                        )
                     };
 
                     if let Err(e) = run_result {
@@ -21472,6 +21485,7 @@ fn warn_tui_terminal_profile(stderr_is_tty: bool) {
 
 fn prepare_headless_once_tui_artifacts(
     data_dir: &Path,
+    db_path: &Path,
     asciicast_path: Option<&Path>,
 ) -> Result<()> {
     std::fs::create_dir_all(data_dir).map_err(|e| {
@@ -21481,7 +21495,16 @@ fn prepare_headless_once_tui_artifacts(
         )
     })?;
 
-    let db_path = data_dir.join("agent_search.db");
+    if let Some(parent) = db_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            anyhow::anyhow!(
+                "create headless --once database parent {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
     {
         let _conn = crate::franken_sync::Connection::open(db_path.to_string_lossy().as_ref())
             .map_err(|e| {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -23279,6 +23279,7 @@ pub fn run_tui_ftui(
     inline_config: Option<InlineTuiConfig>,
     macro_config: MacroConfig,
     data_dir_override: Option<PathBuf>,
+    db_path_override: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     use ftui::ProgramConfig;
     use ftui::core::capability_override::{CapabilityOverride, push_override};
@@ -23339,7 +23340,7 @@ pub fn run_tui_ftui(
     }
     let data_dir = data_dir_override.unwrap_or_else(crate::default_data_dir);
     model.data_dir = data_dir.clone();
-    model.db_path = data_dir.join("agent_search.db");
+    model.db_path = db_path_override.unwrap_or_else(|| data_dir.join("agent_search.db"));
     model.refresh_doctor_hud_summary_from_cached_state();
     if model.db_path.exists() {
         match crate::storage::sqlite::FrankenStorage::open_readonly(&model.db_path) {

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -4249,6 +4249,76 @@ fn doctor_json_reports_interrupted_operation_state_without_deleting_artifacts() 
 }
 
 #[test]
+fn doctor_json_keeps_conversation_id_distinct_from_source_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let test_home = temp.path();
+    let data_dir = test_home.join("cass-data");
+    seed_healthy_empty_index(test_home, &data_dir);
+
+    let source_path = test_home.join(".codex/sessions/project/one.jsonl");
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source dir");
+    fs::write(
+        &source_path,
+        b"{\"type\":\"message\",\"text\":\"fixture\"}\n",
+    )
+    .expect("write source fixture");
+
+    let db_path = data_dir.join("agent_search.db");
+    let conn = FrankenConnection::open(db_path.to_string_lossy().into_owned()).expect("open db");
+    let agent_id = ensure_codex_agent(&conn);
+    let source_path_text = source_path.to_string_lossy().into_owned();
+    conn.execute_compat(
+        "INSERT INTO conversations (id, agent_id, source_id, external_id, title, source_path, started_at)
+         VALUES (9001, ?1, 'local', 'typed-identity-fixture', 'typed identity fixture', ?2, 1700000000000)",
+        coding_agent_search::franken_sync::params![agent_id, source_path_text.as_str()],
+    )
+    .expect("insert conversation");
+    drop(conn);
+
+    let out = cass_cmd(test_home)
+        .args([
+            "doctor",
+            "--json",
+            "--data-dir",
+            data_dir.to_str().expect("utf8"),
+        ])
+        .output()
+        .expect("run cass doctor --json");
+    assert!(
+        out.status.success(),
+        "doctor fixture failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&out.stdout).expect("doctor json");
+    let receipt = payload["raw_mirror_backfill"]["receipts"]
+        .as_array()
+        .expect("backfill receipts")
+        .iter()
+        .find(|receipt| receipt["conversation_id"].as_i64() == Some(9001))
+        .expect("conversation receipt");
+    assert_eq!(receipt["conversation_id"].as_i64(), Some(9001));
+    assert_eq!(
+        receipt["redacted_source_path"].as_str(),
+        Some("[external]/one.jsonl")
+    );
+    assert_eq!(
+        receipt["source_stat_snapshot"]["exists"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        receipt["source_stat_snapshot"]["file_type"].as_str(),
+        Some("file")
+    );
+    assert_ne!(
+        receipt["redacted_source_path"].as_str(),
+        Some("9001"),
+        "a numeric conversation row id must never be rendered as a filesystem path"
+    );
+}
+
+#[test]
 fn doctor_json_reports_missing_upstream_source_as_coverage_risk_not_data_loss() {
     let temp = tempfile::tempdir().expect("tempdir");
     let test_home = temp.path();

--- a/tests/tui_headless_smoke.rs
+++ b/tests/tui_headless_smoke.rs
@@ -109,6 +109,62 @@ fn tui_headless_handles_empty_data_dir() {
 }
 
 #[test]
+fn tui_headless_global_db_uses_db_parent_for_all_assets() {
+    let tmp = TempDir::new().unwrap();
+    let custom_db = tmp.path().join("custom/archive/agent_search.db");
+    let default_data_dir = tmp.path().join(".local/share/coding-agent-search");
+
+    let mut cmd = base_cmd(tmp.path());
+    cmd.args(["--db", custom_db.to_str().unwrap(), "tui", "--once"]);
+    cmd.assert().success();
+
+    let custom_data_dir = custom_db.parent().unwrap();
+    assert!(
+        custom_db.is_file(),
+        "TUI should initialize the global --db path"
+    );
+    assert!(
+        custom_data_dir.join("index").is_dir(),
+        "TUI should place derived index assets beside a custom --db"
+    );
+    assert!(
+        !default_data_dir.exists(),
+        "TUI should not initialize the default data directory for a custom --db"
+    );
+}
+
+#[test]
+fn tui_headless_explicit_data_dir_wins_over_global_db_parent() {
+    let tmp = TempDir::new().unwrap();
+    let explicit_data_dir = tmp.path().join("explicit-data");
+    let custom_db = tmp.path().join("custom/archive/agent_search.db");
+
+    let mut cmd = base_cmd(tmp.path());
+    cmd.args([
+        "--db",
+        custom_db.to_str().unwrap(),
+        "tui",
+        "--once",
+        "--data-dir",
+        explicit_data_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    assert!(
+        custom_db.is_file(),
+        "global --db should remain the database path"
+    );
+    assert!(
+        explicit_data_dir.join("index").is_dir(),
+        "explicit TUI --data-dir should receive derived assets"
+    );
+    assert!(
+        !custom_db.parent().unwrap().join("index").exists(),
+        "global --db parent must not win over explicit TUI --data-dir"
+    );
+}
+
+#[test]
 fn tui_headless_no_panic_on_empty_dataset() {
     // Test: TUI doesn't panic when index exists but is empty
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- resolve TUI data assets with precedence: explicit `tui --data-dir`, global `--db` parent, then default
- preserve the explicit global database path for TUI, refresh, semantic setup, and headless bootstrap
- add focused doctor identity and headless TUI regression fixtures

## Verification

- `cargo +stable metadata --no-deps --format-version 1` passed
- `rustfmt --edition 2024 --check tests/tui_headless_smoke.rs` passed
- `git diff --check` passed
- full Rust tests were not run: this worktree has no compatible build target/cache and the configured nightly toolchain attempted component downloads; disk-constrained instructions prohibit a broad build
- UBS was started on the four changed files but exceeded the 60-second local check window

The source-level doctor fixture asserts that `conversation_id` remains numeric while `source_path` remains an independently redacted/stat-ed path. The focused fixtures are ready for CI execution.