### PR TITLE
fix(search): keep canonical reads FTS-independent

### DIFF
--- a/src/franken_sync.rs
+++ b/src/franken_sync.rs
@@ -97,6 +97,16 @@ impl Connection {
         })
     }
 
+    /// Open an existing database read-only while leaving FTS5 virtual tables
+    /// unhydrated. Canonical tables remain available through pager cursors.
+    pub fn open_schema_only_deferred_fts5(path: impl Into<String>) -> Result<Self, FrankenError> {
+        Ok(Self {
+            inner: drive(frankensqlite::Connection::open_schema_only_deferred_fts5(
+                path,
+            ))?,
+        })
+    }
+
     /// Open an existing database only, deferring FTS5 shadow-table
     /// validation (corrupt-shadow repair path, cass#368 defect 3).
     pub fn open_existing_schema_only_deferred_fts5(

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -2668,7 +2668,7 @@ fn confirm_nonresumable_pending_lexical_rebuild_state_from_readonly_db(
     state: &LexicalRebuildState,
     db_path: &Path,
 ) -> Result<Option<(MatchingLexicalRebuildStateStatus, usize)>> {
-    let mut storage = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let mut storage = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "opening readonly storage to classify pending lexical rebuild checkpoint: {}",
             db_path.display()
@@ -2721,7 +2721,7 @@ fn try_readonly_canonical_force_rebuild(
         return Ok(false);
     }
 
-    let storage = FrankenStorage::open_readonly(&opts.db_path).with_context(|| {
+    let storage = FrankenStorage::open_canonical_readonly(&opts.db_path).with_context(|| {
         format!(
             "opening canonical database read-only for force rebuild: {}",
             opts.db_path.display()
@@ -9071,7 +9071,7 @@ fn lexical_rebuild_content_fingerprint(
 }
 
 fn lexical_rebuild_storage_fingerprint(db_path: &Path) -> Result<String> {
-    let mut storage = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let mut storage = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "opening readonly storage to compute lexical fingerprint for {}",
             db_path.display()
@@ -9482,7 +9482,7 @@ fn can_skip_absent_explicit_watch_once_index_run(opts: &IndexOptions) -> bool {
     if !should_skip_absent_explicit_watch_once_paths(opts) {
         return false;
     }
-    let Ok(storage) = FrankenStorage::open_readonly(&opts.db_path) else {
+    let Ok(storage) = FrankenStorage::open_canonical_readonly(&opts.db_path) else {
         return false;
     };
     let db_schema_current = matches!(
@@ -10841,7 +10841,7 @@ pub(crate) fn lexical_storage_fingerprint_for_db(db_path: &Path) -> Result<Strin
 /// opener. Used by strict read-only search so a dirty WAL or duplicate schema
 /// is surfaced rather than repaired as a side effect of freshness validation.
 pub(crate) fn lexical_storage_fingerprint_for_db_strict(db_path: &Path) -> Result<String> {
-    let storage = FrankenStorage::open_strict_readonly(db_path).with_context(|| {
+    let storage = FrankenStorage::open_canonical_strict_readonly(db_path).with_context(|| {
         format!(
             "strictly opening readonly storage to compute lexical fingerprint for {}",
             db_path.display()
@@ -11057,7 +11057,7 @@ fn refresh_completed_lexical_rebuild_checkpoint_for_final_state(
     // fingerprint from that fresh snapshot, and avoids a redundant second open
     // just to rebuild the same lexical storage fingerprint.
     storage.close_best_effort_in_place();
-    let mut settled = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let mut settled = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "reopening readonly storage to refresh settled lexical checkpoint for {}",
             db_path.display()
@@ -15543,7 +15543,7 @@ pub fn run_index(
                 0,
                 0,
             );
-            let mut semantic_read_storage = FrankenStorage::open_readonly(&opts.db_path)
+            let mut semantic_read_storage = FrankenStorage::open_canonical_readonly(&opts.db_path)
                 .with_context(|| {
                     format!(
                         "opening fresh readonly canonical storage for semantic indexing: {}",
@@ -18333,7 +18333,7 @@ pub(crate) fn refresh_completed_lexical_rebuild_checkpoint_from_live_index(
     db_path: &Path,
     data_dir: &Path,
 ) -> Result<()> {
-    let storage = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let storage = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "opening database to refresh lexical checkpoint: {}",
             db_path.display()
@@ -18364,7 +18364,7 @@ pub(crate) fn repair_lexical_index_from_canonical_db_for_search(
     // debris from previous crashed runs while we hold the exclusive lock.
     staging_reclaim::reclaim_orphaned_staging_dirs_for_data_dir(data_dir, SystemTime::now()).log();
 
-    let storage = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let storage = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "opening database to repair lexical index for search: {}",
             db_path.display()
@@ -18845,7 +18845,7 @@ fn spawn_lexical_rebuild_page_prep_workers(
                         // active.  Require an already-readable archive here and
                         // leave any repair to the single mutating owner.
                         let mut storage =
-                            match FrankenStorage::open_strict_readonly(&worker_db_path) {
+                            match FrankenStorage::open_canonical_strict_readonly(&worker_db_path) {
                             Ok(storage) => storage,
                             Err(err) => {
                                 let _ = worker_result_tx.send(LexicalRebuildPagePrepResult::Error {
@@ -18981,7 +18981,7 @@ fn spawn_lexical_rebuild_packet_producer(
                 let _ = tx.send(LexicalRebuildPipelineMessage::Error(format!("{error:#}")));
             };
 
-            let mut storage = match FrankenStorage::open_readonly(&db_path) {
+            let mut storage = match FrankenStorage::open_canonical_readonly(&db_path) {
                 Ok(storage) => storage,
                 Err(err) => {
                     send_error(err.context(format!(
@@ -21677,7 +21677,7 @@ fn rebuild_tantivy_from_db_with_options(
         *step_started = Instant::now();
     };
 
-    let storage = FrankenStorage::open_readonly(db_path).with_context(|| {
+    let storage = FrankenStorage::open_canonical_readonly(db_path).with_context(|| {
         format!(
             "opening database for Tantivy rebuild: {}",
             db_path.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17497,7 +17497,7 @@ fn open_franken_analytics_db(
     data_dir: &Option<PathBuf>,
     db_path_override: Option<&PathBuf>,
 ) -> CliResult<crate::franken_sync::Connection> {
-    open_franken_cli_read_db(
+    open_franken_cli_canonical_read_db(
         analytics_db_path(data_dir, db_path_override),
         "analytics",
         Duration::from_secs(1),
@@ -17516,6 +17516,29 @@ fn open_franken_cli_read_db(
     reason: &str,
     busy_timeout: Duration,
 ) -> CliResult<crate::franken_sync::Connection> {
+    open_franken_cli_read_db_for_scope(path, reason, busy_timeout, CliReadDbScope::Full)
+}
+
+fn open_franken_cli_canonical_read_db(
+    path: PathBuf,
+    reason: &str,
+    busy_timeout: Duration,
+) -> CliResult<crate::franken_sync::Connection> {
+    open_franken_cli_read_db_for_scope(path, reason, busy_timeout, CliReadDbScope::Canonical)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CliReadDbScope {
+    Canonical,
+    Full,
+}
+
+fn open_franken_cli_read_db_for_scope(
+    path: PathBuf,
+    reason: &str,
+    busy_timeout: Duration,
+    scope: CliReadDbScope,
+) -> CliResult<crate::franken_sync::Connection> {
     if !path.exists() {
         return Err(CliError {
             code: 3,
@@ -17529,13 +17552,39 @@ fn open_franken_cli_read_db(
         });
     }
 
-    let conn = match crate::storage::sqlite::open_franken_readonly_storage_with_timeout(
-        &path,
-        busy_timeout,
-    ) {
+    let storage_open = match scope {
+        CliReadDbScope::Canonical => {
+            crate::storage::sqlite::open_franken_canonical_readonly_storage_with_timeout(
+                &path,
+                busy_timeout,
+            )
+        }
+        CliReadDbScope::Full => {
+            crate::storage::sqlite::open_franken_readonly_storage_with_timeout(&path, busy_timeout)
+        }
+    };
+    let conn = match storage_open {
         Ok(storage) => storage.into_raw(),
         Err(err) => {
             let readonly_retryable = crate::storage::sqlite::retryable_franken_anyhow(&err);
+            if scope == CliReadDbScope::Canonical {
+                let message = format!(
+                    "Failed to open {reason} database at {}: canonical readonly storage open failed ({err})",
+                    path.display()
+                );
+                if let Some(fts_err) =
+                    crate::storage::sqlite::fts_messages_integrity_error_from_message(&message)
+                {
+                    return Err(fts_messages_integrity_cli_error(reason, fts_err.into()));
+                }
+                return Err(CliError {
+                    code: 9,
+                    kind: CliErrorKind::DbOpen.kind_str(),
+                    message,
+                    hint: None,
+                    retryable: readonly_retryable,
+                });
+            }
             match crate::storage::sqlite::open_franken_raw_readonly_connection_with_timeout(
                 &path,
                 busy_timeout,
@@ -19490,10 +19539,10 @@ pub(crate) fn bounded_canonical_db_corruption_probe(
         return None;
     }
 
-    match open_franken_cli_read_db(db_path.to_path_buf(), reason, STATE_DB_OPEN_TIMEOUT) {
+    match open_franken_cli_canonical_read_db(db_path.to_path_buf(), reason, STATE_DB_OPEN_TIMEOUT) {
         Ok(conn) => {
             let (integrity, detail) = probe_state_db_integrity(&conn);
-            let _ = close_franken_cli_read_db(conn, db_path, reason);
+            let _ = close_franken_cli_read_db_without_checkpoint(conn, db_path, reason);
             match integrity {
                 Some(StateDbIntegrity::Corrupt) => {
                     Some(detail.unwrap_or_else(|| "corruption-class read failure".to_owned()))
@@ -19555,7 +19604,7 @@ fn probe_state_db_modes(
         ..StateDbSnapshot::default()
     };
 
-    let conn = match open_franken_cli_read_db(db_path.to_path_buf(), reason, timeout) {
+    let conn = match open_franken_cli_canonical_read_db(db_path.to_path_buf(), reason, timeout) {
         Ok(conn) => conn,
         Err(err) => {
             if watermarks_only && err.retryable {
@@ -19675,7 +19724,7 @@ fn probe_state_db_modes(
         }
     }
 
-    if let Err(err) = close_franken_cli_read_db(conn, db_path, reason) {
+    if let Err(err) = close_franken_cli_read_db_without_checkpoint(conn, db_path, reason) {
         snapshot.open_error = Some(err.message);
     }
 
@@ -99499,7 +99548,7 @@ fn count_indexed_session_paths(
     if requested.is_empty() || !db_path.is_file() {
         return None;
     }
-    let conn = open_franken_cli_read_db(
+    let conn = open_franken_cli_canonical_read_db(
         db_path.to_path_buf(),
         "sessions-from-resolution",
         Duration::from_secs(2),
@@ -99528,7 +99577,7 @@ fn count_indexed_session_paths(
             }
         }
     }
-    let _ = close_franken_cli_read_db(conn, db_path, "sessions-from-resolution");
+    let _ = close_franken_cli_read_db_without_checkpoint(conn, db_path, "sessions-from-resolution");
     complete.then_some(matched)
 }
 

--- a/src/search/asset_state.rs
+++ b/src/search/asset_state.rs
@@ -751,7 +751,7 @@ fn apply_semantic_identity_invalidation(
         SemanticPreference::HashFallback => SemanticIdentityTier::Fast,
         SemanticPreference::DefaultModel => SemanticIdentityTier::Quality,
     };
-    let storage = match FrankenStorage::open_readonly(db_path) {
+    let storage = match FrankenStorage::open_canonical_readonly(db_path) {
         Ok(storage) => storage,
         Err(err) => {
             // `db_available` is a point-in-time observation, not proof that

--- a/src/search/model_manager.rs
+++ b/src/search/model_manager.rs
@@ -785,9 +785,9 @@ fn load_hash_semantic_context_inner(
     }
 
     let storage = match if strict_read_only {
-        FrankenStorage::open_strict_readonly(db_path)
+        FrankenStorage::open_canonical_strict_readonly(db_path)
     } else {
-        FrankenStorage::open_readonly(db_path)
+        FrankenStorage::open_canonical_readonly(db_path)
     } {
         Ok(storage) => storage,
         Err(err) => {
@@ -966,9 +966,9 @@ fn load_semantic_context_inner(
     }
 
     let storage = match if strict_read_only {
-        FrankenStorage::open_strict_readonly(db_path)
+        FrankenStorage::open_canonical_strict_readonly(db_path)
     } else {
-        FrankenStorage::open_readonly(db_path)
+        FrankenStorage::open_canonical_readonly(db_path)
     } {
         Ok(storage) => storage,
         Err(err) => {

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -311,13 +311,29 @@ fn open_search_hydration_sqlite(
     path: &Path,
     timeout: Duration,
     strict_read_only: bool,
+    defer_fts5_hydration: bool,
 ) -> Result<SearchSqliteConnection> {
-    let conn = if strict_read_only {
-        crate::storage::sqlite::open_franken_async_strict_readonly_connection_with_timeout(
-            path, timeout,
-        )?
-    } else {
-        crate::storage::sqlite::open_franken_async_readonly_connection_with_timeout(path, timeout)?
+    let conn = match (strict_read_only, defer_fts5_hydration) {
+        (true, true) => {
+            crate::storage::sqlite::open_franken_async_canonical_strict_readonly_connection_with_timeout(
+                path, timeout,
+            )?
+        }
+        (true, false) => {
+            crate::storage::sqlite::open_franken_async_strict_readonly_connection_with_timeout(
+                path, timeout,
+            )?
+        }
+        (false, true) => {
+            crate::storage::sqlite::open_franken_async_canonical_readonly_connection_with_timeout(
+                path, timeout,
+            )?
+        }
+        (false, false) => {
+            crate::storage::sqlite::open_franken_async_readonly_connection_with_timeout(
+                path, timeout,
+            )?
+        }
     };
     conn.execute_sync("PRAGMA query_only = 1;")
         .with_context(|| "setting search hydration query_only")?;
@@ -3989,10 +4005,19 @@ impl SearchClient {
         if guard.is_none()
             && let Some(path) = &self.sqlite_path
         {
+            // An external reader owns retrieval whenever it exists. SQLite
+            // then serves canonical hydration/filter data only, so leave its
+            // legacy derived FTS index unhydrated. The SQLite fallback lane
+            // still opens FTS normally.
+            let defer_fts5_hydration = self.reader.is_some()
+                || FEDERATED_SEARCH_READERS
+                    .read()
+                    .contains_key(&self.cache_namespace);
             match open_search_hydration_sqlite(
                 path,
                 std::time::Duration::from_secs(1),
                 self.strict_read_only,
+                defer_fts5_hydration,
             ) {
                 Ok(conn) => {
                     *guard = Some(conn);

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -741,6 +741,21 @@ pub(crate) fn open_franken_readonly_storage_with_timeout(
     path: &Path,
     timeout: Duration,
 ) -> Result<FrankenStorage> {
+    open_franken_readonly_storage_with_options(path, timeout, false)
+}
+
+pub(crate) fn open_franken_canonical_readonly_storage_with_timeout(
+    path: &Path,
+    timeout: Duration,
+) -> Result<FrankenStorage> {
+    open_franken_readonly_storage_with_options(path, timeout, true)
+}
+
+fn open_franken_readonly_storage_with_options(
+    path: &Path,
+    timeout: Duration,
+    defer_fts5_hydration: bool,
+) -> Result<FrankenStorage> {
     if !path.exists() {
         return Err(anyhow!("Database not found at {}", path.display()));
     }
@@ -748,7 +763,12 @@ pub(crate) fn open_franken_readonly_storage_with_timeout(
     let deadline = Instant::now() + timeout;
     let mut backoff = Duration::from_millis(4);
     loop {
-        match FrankenStorage::open_readonly(path) {
+        let open_result = if defer_fts5_hydration {
+            FrankenStorage::open_canonical_readonly_with_doctor_lock_timeout(path, timeout)
+        } else {
+            FrankenStorage::open_readonly(path)
+        };
+        match open_result {
             Ok(storage) => return Ok(storage),
             Err(err) if retryable_franken_anyhow(&err) => {
                 let now = Instant::now();
@@ -862,6 +882,24 @@ pub(crate) fn open_franken_async_readonly_connection_with_timeout(
     path: &Path,
     timeout: Duration,
 ) -> Result<FrankenAsyncConnection> {
+    open_franken_async_readonly_connection_with_options(path, timeout, false)
+}
+
+/// Open the canonical archive for queries that never touch `fts_messages`.
+/// Legacy in-database FTS state stays unhydrated; ordinary tables are still
+/// read through the pager and the connection remains read-only.
+pub(crate) fn open_franken_async_canonical_readonly_connection_with_timeout(
+    path: &Path,
+    timeout: Duration,
+) -> Result<FrankenAsyncConnection> {
+    open_franken_async_readonly_connection_with_options(path, timeout, true)
+}
+
+fn open_franken_async_readonly_connection_with_options(
+    path: &Path,
+    timeout: Duration,
+    defer_fts5_hydration: bool,
+) -> Result<FrankenAsyncConnection> {
     if !path.exists() {
         return Err(anyhow!("Database not found at {}", path.display()));
     }
@@ -873,11 +911,15 @@ pub(crate) fn open_franken_async_readonly_connection_with_timeout(
     let mut duplicate_fts_repair_attempted = false;
     loop {
         let _doctor_guard = acquire_doctor_mutation_db_open_guard(path, timeout)?;
-        match FrankenAsyncConnection::open_with_flags_sync(
-            &path_str,
-            FrankenOpenFlags::SQLITE_OPEN_READ_ONLY,
-        )
-        .with_context(|| {
+        let open_result = if defer_fts5_hydration {
+            FrankenAsyncConnection::open_schema_only_deferred_fts5_sync(&path_str)
+        } else {
+            FrankenAsyncConnection::open_with_flags_sync(
+                &path_str,
+                FrankenOpenFlags::SQLITE_OPEN_READ_ONLY,
+            )
+        };
+        match open_result.with_context(|| {
             format!(
                 "opening dedicated-owner frankensqlite db readonly at {}",
                 path.display()
@@ -927,6 +969,21 @@ pub(crate) fn open_franken_async_strict_readonly_connection_with_timeout(
     path: &Path,
     timeout: Duration,
 ) -> Result<FrankenAsyncConnection> {
+    open_franken_async_strict_readonly_connection_with_options(path, timeout, false)
+}
+
+pub(crate) fn open_franken_async_canonical_strict_readonly_connection_with_timeout(
+    path: &Path,
+    timeout: Duration,
+) -> Result<FrankenAsyncConnection> {
+    open_franken_async_strict_readonly_connection_with_options(path, timeout, true)
+}
+
+fn open_franken_async_strict_readonly_connection_with_options(
+    path: &Path,
+    timeout: Duration,
+    defer_fts5_hydration: bool,
+) -> Result<FrankenAsyncConnection> {
     if !path.exists() {
         return Err(anyhow!("Database not found at {}", path.display()));
     }
@@ -937,11 +994,15 @@ pub(crate) fn open_franken_async_strict_readonly_connection_with_timeout(
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         let _doctor_guard = acquire_existing_doctor_mutation_db_open_guard(path, remaining)?;
-        match FrankenAsyncConnection::open_with_flags_sync(
-            &path_str,
-            FrankenOpenFlags::SQLITE_OPEN_READ_ONLY,
-        )
-        .with_context(|| {
+        let open_result = if defer_fts5_hydration {
+            FrankenAsyncConnection::open_schema_only_deferred_fts5_sync(&path_str)
+        } else {
+            FrankenAsyncConnection::open_with_flags_sync(
+                &path_str,
+                FrankenOpenFlags::SQLITE_OPEN_READ_ONLY,
+            )
+        };
+        match open_result.with_context(|| {
             format!(
                 "strictly opening dedicated-owner frankensqlite db readonly at {}",
                 path.display()
@@ -5263,11 +5324,35 @@ impl FrankenStorage {
         Self::open_readonly_with_doctor_lock_timeout(path, DOCTOR_MUTATION_DB_OPEN_LOCK_TIMEOUT)
     }
 
+    /// Open canonical CASS tables read-only without hydrating the derived
+    /// in-database FTS5 index.
+    pub fn open_canonical_readonly(path: &Path) -> Result<Self> {
+        Self::open_canonical_readonly_with_doctor_lock_timeout(
+            path,
+            DOCTOR_MUTATION_DB_OPEN_LOCK_TIMEOUT,
+        )
+    }
+
     /// Open in read-only mode with an explicit doctor mutation-lock timeout.
     ///
     /// This is primarily useful for probes that need to prove a reader would
     /// not enter the archive while `cass doctor --fix` owns the repair lock.
     pub fn open_readonly_with_doctor_lock_timeout(path: &Path, timeout: Duration) -> Result<Self> {
+        Self::open_readonly_with_options(path, timeout, false)
+    }
+
+    pub fn open_canonical_readonly_with_doctor_lock_timeout(
+        path: &Path,
+        timeout: Duration,
+    ) -> Result<Self> {
+        Self::open_readonly_with_options(path, timeout, true)
+    }
+
+    fn open_readonly_with_options(
+        path: &Path,
+        timeout: Duration,
+        defer_fts5_hydration: bool,
+    ) -> Result<Self> {
         let path_str = path.to_string_lossy().to_string();
         let _doctor_guard = acquire_doctor_mutation_db_open_guard(path, timeout)?;
         // fsqlite 0.3.x surfaces transient `BusyRecovery` from a readonly open
@@ -5275,9 +5360,15 @@ impl FrankenStorage {
         // class upstream retries in prepare's prologue since 55d7f2c5). The
         // lexical-rebuild page-prep workers open readonly right next to the
         // active writer, so a bounded retry here is load-bearing.
+        let open_connection = || {
+            if defer_fts5_hydration {
+                FrankenConnection::open_schema_only_deferred_fts5(&path_str)
+            } else {
+                open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
+            }
+        };
         let conn = match retry_transient_storage_op("open_readonly", || {
-            open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
-                .map_err(anyhow::Error::new)
+            open_connection().map_err(anyhow::Error::new)
         }) {
             Ok(conn) => conn,
             // Same duplicate-fts_messages debris handling as the canonical
@@ -5293,8 +5384,7 @@ impl FrankenStorage {
                      fts_messages schema rows; deduplicating via sqlite3 bridge"
                 );
                 dedupe_conflicting_fts_schema_rows_via_sqlite3(path)?;
-                open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
-                    .map_err(anyhow::Error::new)?
+                open_connection().map_err(anyhow::Error::new)?
             }
             // gh #389: a hard (non-busy) readonly failure with a non-empty
             // `-wal` present is the unclean-shutdown dirty-WAL shape — the
@@ -5303,7 +5393,7 @@ impl FrankenStorage {
             // shutdown path uses, then retry the readonly open once. The
             // doctor mutation guard acquired above is still held here.
             Err(err) if attempt_dirty_wal_recovery_checkpoint(path, &err) => {
-                open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
+                open_connection()
                     .map_err(anyhow::Error::new)
                     .with_context(|| {
                         format!(
@@ -5338,6 +5428,29 @@ impl FrankenStorage {
         path: &Path,
         timeout: Duration,
     ) -> Result<Self> {
+        Self::open_strict_readonly_with_options(path, timeout, false)
+    }
+
+    /// Open canonical archive tables without recovery writes or FTS hydration.
+    pub(crate) fn open_canonical_strict_readonly(path: &Path) -> Result<Self> {
+        Self::open_canonical_strict_readonly_with_timeout(
+            path,
+            DOCTOR_MUTATION_DB_OPEN_LOCK_TIMEOUT,
+        )
+    }
+
+    pub(crate) fn open_canonical_strict_readonly_with_timeout(
+        path: &Path,
+        timeout: Duration,
+    ) -> Result<Self> {
+        Self::open_strict_readonly_with_options(path, timeout, true)
+    }
+
+    fn open_strict_readonly_with_options(
+        path: &Path,
+        timeout: Duration,
+        defer_fts5_hydration: bool,
+    ) -> Result<Self> {
         let path_str = path.to_string_lossy().to_string();
         // The caller supplies one end-to-end admission/open budget. Starting
         // the deadline after the doctor guard was acquired allowed a busy
@@ -5348,9 +5461,12 @@ impl FrankenStorage {
         let _doctor_guard = acquire_existing_doctor_mutation_db_open_guard(path, timeout)?;
         let mut backoff = Duration::from_millis(4);
         let conn = loop {
-            match open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
-                .map_err(anyhow::Error::new)
-            {
+            let open_result = if defer_fts5_hydration {
+                FrankenConnection::open_schema_only_deferred_fts5(&path_str)
+            } else {
+                open_franken_with_flags(&path_str, FrankenOpenFlags::SQLITE_OPEN_READ_ONLY)
+            };
+            match open_result.map_err(anyhow::Error::new) {
                 Ok(conn) => break conn,
                 Err(err) if retryable_franken_anyhow(&err) => {
                     let now = Instant::now();
@@ -23000,6 +23116,20 @@ mod tests {
         assert!(storage.schema_version().is_ok());
     }
 
+    #[test]
+    fn open_canonical_readonly_reads_schema_and_refuses_writes() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("canonical-readonly.db");
+        drop(SqliteStorage::open(&db_path).unwrap());
+
+        let storage = SqliteStorage::open_canonical_readonly(&db_path).unwrap();
+        assert!(storage.schema_version().is_ok());
+        storage
+            .raw()
+            .execute("CREATE TABLE refused(id INTEGER)")
+            .expect_err("canonical deferred-fts5 connection must remain read-only");
+    }
+
     // gh #389: dirty-WAL recovery must never fire without a non-empty WAL
     // sidecar, and must never fire on retryable (live-writer) failures.
     #[test]
@@ -23179,8 +23309,8 @@ mod tests {
         assert_eq!(rows[0].get_typed::<i64>(0).unwrap(), 3);
         owner.close_without_checkpoint_sync().unwrap();
 
-        let strict_storage =
-            FrankenStorage::open_strict_readonly(&db_path).expect("strict storage read open");
+        let strict_storage = FrankenStorage::open_canonical_strict_readonly(&db_path)
+            .expect("strict canonical storage read open");
         let count: i64 = strict_storage
             .raw()
             .query_row_map("SELECT COUNT(*) FROM t;", &[] as &[ParamValue], |row| {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -23309,8 +23309,20 @@ mod tests {
         assert_eq!(rows[0].get_typed::<i64>(0).unwrap(), 3);
         owner.close_without_checkpoint_sync().unwrap();
 
-        let strict_storage = FrankenStorage::open_canonical_strict_readonly(&db_path)
-            .expect("strict canonical storage read open");
+        let mut canonical_owner =
+            open_franken_async_canonical_strict_readonly_connection_with_timeout(
+                &db_path,
+                Duration::from_secs(2),
+            )
+            .expect("strict canonical dedicated-owner read open");
+        let rows = canonical_owner
+            .query_sync("SELECT COUNT(*) FROM t;")
+            .unwrap();
+        assert_eq!(rows[0].get_typed::<i64>(0).unwrap(), 3);
+        canonical_owner.close_without_checkpoint_sync().unwrap();
+
+        let strict_storage =
+            FrankenStorage::open_strict_readonly(&db_path).expect("strict storage read open");
         let count: i64 = strict_storage
             .raw()
             .query_row_map("SELECT COUNT(*) FROM t;", &[] as &[ParamValue], |row| {
@@ -23319,6 +23331,19 @@ mod tests {
             .unwrap();
         assert_eq!(count, 3);
         strict_storage.close_without_checkpoint().unwrap();
+
+        let canonical_strict_storage = FrankenStorage::open_canonical_strict_readonly(&db_path)
+            .expect("strict canonical storage read open");
+        let count: i64 = canonical_strict_storage
+            .raw()
+            .query_row_map("SELECT COUNT(*) FROM t;", &[] as &[ParamValue], |row| {
+                row.get_typed(0)
+            })
+            .unwrap();
+        assert_eq!(count, 3);
+        canonical_strict_storage
+            .close_without_checkpoint()
+            .unwrap();
 
         assert_eq!(before, bundle_snapshot());
         assert!(


### PR DESCRIPTION
## Status

Draft and intentionally blocked on [FrankenSQLite #401](https://github.com/Dicklesworthstone/frankensqlite/pull/401) plus a subsequent crates.io release. This branch does not commit a local path override or weaken CASS's dependency-source contract, so CI against the current registry release is expected to lack the new open method.

## Summary

- add explicit full-data and canonical-data read scopes
- keep canonical CASS table reads pager-backed while leaving legacy SQLite FTS unhydrated
- select that bounded lane only when Tantivy/Quill/federated retrieval is authoritative
- preserve normal SQLite FTS hydration for the SQLite lexical fallback
- retain strict and non-strict variants, including their existing doctor-lock and recovery semantics

## Problem

CASS can use an external lexical reader for retrieval while still opening SQLite to hydrate canonical rows, resolve filters, read status watermarks, or rebuild external indexes. Those paths do not query `fts_messages`, but a normal FrankenSQLite open still validates and hydrates the derived FTS state.

On a large archive, a small canonical read can therefore pay memory and latency proportional to an unrelated legacy index. The retrieval backend itself is not the expensive part.

## Routing invariant

The change does not globally disable SQLite FTS:

- external reader present: SQLite is canonical hydration/filter storage, so use the deferred-FTS schema-only reader
- no external reader: SQLite is the lexical fallback, so retain the existing full reader
- explicit integrity/repair work: retain the existing full reader
- strict no-maintenance callers: preserve strict admission behavior, with separate full and canonical variants

The same canonical reader is used for status/health watermarks, analytics, semantic metadata, session-filter resolution, and Tantivy rebuild inputs because those call sites read ordinary CASS tables only.

## Verification

An isolated integration worktree pointed this branch at FrankenSQLite #401 without committing any source override. On current CASS `main`:

```text
cargo test --lib open_canonical_readonly_reads_schema_and_refuses_writes
1 passed

cargo test --lib gh422_strict_read_openers_do_not_create_lock_state_or_change_database_bundle
1 passed

rustfmt --check (targeted changed modules)
git diff --check
```

The strict regression exercises the ordinary and canonical dedicated-owner readers plus the ordinary and canonical storage readers. All four read the same canonical table, and the database bundle and doctor-lock hierarchy remain byte-for-byte/structurally unchanged.

In an out-of-tree downstream check against a multi-gigabyte archive, representative canonical reads stayed around 1.3-2.2 GB RSS and completed in roughly 2.6-5.1 seconds. The previous path reached roughly 8.7 GB RSS and took 8.6-13.3 seconds or failed to complete. No downstream paths, corpus data, or query content are included here.

## Scope

This is a reference integration for review alongside the engine change. It deliberately does not change query ranking, index formats, repair policy, or the SQLite fallback. A maintainer rewrite that preserves the routing invariant is welcome.
